### PR TITLE
✨ state_store, article_repository を実装 (#5)

### DIFF
--- a/src/article_repository.py
+++ b/src/article_repository.py
@@ -1,0 +1,76 @@
+"""記事 JSON の永続化。data/articles/{raindrop_id}.json の CRUD。"""
+
+import json
+import logging
+from pathlib import Path
+
+from src.models import ProcessedArticle
+
+logger = logging.getLogger("raindrop_summarizer")
+
+
+class ArticleRepository:
+    """data/articles/ 配下の記事 JSON を管理する。"""
+
+    def __init__(self, data_dir: str = "data") -> None:
+        self.data_dir = Path(data_dir)
+        self.articles_dir = self.data_dir / "articles"
+        self.output_dir = self.data_dir / "output"
+
+    def save(self, article: ProcessedArticle) -> Path:
+        """記事を JSON ファイルとして保存する。"""
+        self.articles_dir.mkdir(parents=True, exist_ok=True)
+        path = self.articles_dir / f"{article.raindrop_id}.json"
+        data = article.model_dump(mode="json")
+        path.write_text(
+            json.dumps(data, ensure_ascii=False, indent=2),
+            encoding="utf-8",
+        )
+        logger.debug(f"記事を保存: {path}")
+        return path
+
+    def load(self, raindrop_id: int) -> ProcessedArticle | None:
+        """記事を JSON ファイルから読み込む。存在しなければ None。"""
+        path = self.articles_dir / f"{raindrop_id}.json"
+        if not path.exists():
+            return None
+        try:
+            data = json.loads(path.read_text(encoding="utf-8"))
+            return ProcessedArticle.model_validate(data)
+        except Exception:
+            logger.warning(f"記事の読み込みに失敗: {path}")
+            return None
+
+    def list_all(self) -> list[ProcessedArticle]:
+        """保存済みの全記事を読み込む。"""
+        articles: list[ProcessedArticle] = []
+        if not self.articles_dir.exists():
+            return articles
+        for path in sorted(self.articles_dir.glob("*.json")):
+            try:
+                data = json.loads(path.read_text(encoding="utf-8"))
+                articles.append(ProcessedArticle.model_validate(data))
+            except Exception:
+                logger.warning(f"記事の読み込みをスキップ: {path}")
+        return articles
+
+    def export_all(self) -> Path:
+        """全記事を統合した articles.json を出力する。"""
+        self.output_dir.mkdir(parents=True, exist_ok=True)
+        articles = self.list_all()
+        data = [a.model_dump(mode="json") for a in articles]
+        path = self.output_dir / "articles.json"
+        path.write_text(
+            json.dumps(data, ensure_ascii=False, indent=2),
+            encoding="utf-8",
+        )
+        logger.info(f"全記事を出力: {path} ({len(articles)} 件)")
+        return path
+
+    def delete(self, raindrop_id: int) -> bool:
+        """記事ファイルを削除する。"""
+        path = self.articles_dir / f"{raindrop_id}.json"
+        if path.exists():
+            path.unlink()
+            return True
+        return False

--- a/src/state_store.py
+++ b/src/state_store.py
@@ -1,0 +1,94 @@
+"""状態管理。state/index.json の読み書きと差分検出。"""
+
+import json
+import logging
+from pathlib import Path
+
+from src.models import ArticleState, RaindropItem, StateEntry, StateIndex
+from src.utils.time import now_utc
+
+logger = logging.getLogger("raindrop_summarizer")
+
+
+class StateStore:
+    """state/index.json を管理する。"""
+
+    def __init__(self, state_dir: str = "state") -> None:
+        self.state_dir = Path(state_dir)
+        self.index_path = self.state_dir / "index.json"
+        self.index = self._load()
+
+    def _load(self) -> StateIndex:
+        """index.json を読み込む。存在しなければ空の StateIndex を返す。"""
+        if self.index_path.exists():
+            try:
+                data = json.loads(self.index_path.read_text(encoding="utf-8"))
+                return StateIndex.model_validate(data)
+            except Exception:
+                logger.warning("state/index.json の読み込みに失敗。新規作成します。")
+        return StateIndex()
+
+    def save(self) -> None:
+        """index.json を書き出す。"""
+        self.state_dir.mkdir(parents=True, exist_ok=True)
+        data = self.index.model_dump(mode="json")
+        self.index_path.write_text(
+            json.dumps(data, ensure_ascii=False, indent=2),
+            encoding="utf-8",
+        )
+
+    def get_new_articles(
+        self, raindrops: list[RaindropItem], max_count: int = 30
+    ) -> list[RaindropItem]:
+        """未処理の新規記事を抽出する。created_at の新しい順、上限 max_count 件。"""
+        existing_ids = set(self.index.items.keys())
+        new_items = [r for r in raindrops if str(r.raindrop_id) not in existing_ids]
+        new_items.sort(key=lambda r: r.created_at, reverse=True)
+
+        # 上限を超えた分は pending として登録
+        for item in new_items[max_count:]:
+            self._set_entry(str(item.raindrop_id), ArticleState.pending)
+
+        return new_items[:max_count]
+
+    def get_failed_ids(self) -> list[str]:
+        """status が failed のエントリの ID リストを返す。"""
+        return [
+            rid
+            for rid, entry in self.index.items.items()
+            if entry.status == ArticleState.failed
+        ]
+
+    def update_status(
+        self,
+        raindrop_id: int | str,
+        status: ArticleState,
+        content_hash: str | None = None,
+        reason: str | None = None,
+    ) -> None:
+        """エントリの状態を更新する。"""
+        rid = str(raindrop_id)
+        entry = self.index.items.get(rid, StateEntry())
+        entry.status = status
+        entry.updated_at = now_utc()
+        if content_hash is not None:
+            entry.content_hash = content_hash
+        if reason is not None:
+            entry.reason = reason
+        if status == ArticleState.summarized:
+            entry.summarized_at = now_utc()
+        self.index.items[rid] = entry
+
+    def remove_entry(self, raindrop_id: int | str) -> None:
+        """エントリを削除する（再処理用）。"""
+        rid = str(raindrop_id)
+        self.index.items.pop(rid, None)
+
+    def mark_run_completed(self) -> None:
+        """実行完了時刻を記録する。"""
+        self.index.last_run_at = now_utc()
+
+    def _set_entry(self, rid: str, status: ArticleState) -> None:
+        """内部用。エントリを設定する。"""
+        if rid not in self.index.items:
+            self.index.items[rid] = StateEntry(status=status, updated_at=now_utc())


### PR DESCRIPTION
Closes #5

## Summary

- `src/state_store.py` — `state/index.json` の読み書き、新規記事の差分検出（created_at 降順、上限適用）、状態更新、failed 記事取得、再処理用エントリ削除
- `src/article_repository.py` — `data/articles/{id}.json` の保存・読込・一覧・統合出力・削除

## Test plan

- [x] `StateStore`: 3件中 max_count=2 で新しい順に2件抽出、超過分は pending
- [x] `StateStore`: update_status で summarized + content_hash + summarized_at が正しく設定
- [x] `StateStore`: get_failed_ids で failed エントリのみ取得
- [x] `StateStore`: remove_entry でエントリ削除（reprocess 用）
- [x] `StateStore`: save → 別インスタンスで load して永続化を確認
- [x] `ArticleRepository`: save → load で記事の往復を確認
- [x] `ArticleRepository`: 存在しない ID の load が None
- [x] `ArticleRepository`: list_all で保存済み全件取得
- [x] `ArticleRepository`: export_all で統合 JSON を出力
- [x] `ArticleRepository`: delete の成功/失敗

🤖 Generated with [Claude Code](https://claude.com/claude-code)