### PR TITLE
✨ content_fetcher, content_extractor を実装 (#9)

### DIFF
--- a/src/content_extractor.py
+++ b/src/content_extractor.py
@@ -1,0 +1,117 @@
+"""本文抽出。trafilatura → readability-lxml → メタデータフォールバック。"""
+
+import logging
+from dataclasses import dataclass, field
+
+import trafilatura
+from readability import Document
+
+from src.models import RaindropItem, SummaryInputType
+from src.utils.text import clean_text, count_chars
+
+logger = logging.getLogger("raindrop_summarizer")
+
+
+@dataclass
+class ExtractionResult:
+    """本文抽出結果。"""
+
+    text: str = ""
+    method: str = ""
+    summary_input_type: SummaryInputType | None = None
+    ok: bool = False
+    fallback_input: dict = field(default_factory=dict)
+
+
+def extract_body(html: str, raindrop: RaindropItem, og_description: str = "") -> ExtractionResult:
+    """HTML から本文を抽出する。フォールバックチェーン付き。"""
+
+    # 1. trafilatura
+    try:
+        text = trafilatura.extract(html, include_comments=False, include_tables=True)
+        if text and count_chars(text) >= 100:
+            cleaned = clean_text(text)
+            input_type = _classify_length(count_chars(cleaned))
+            logger.debug(f"trafilatura で抽出成功: {count_chars(cleaned)} 文字")
+            return ExtractionResult(
+                text=cleaned,
+                method="trafilatura",
+                summary_input_type=input_type,
+                ok=True,
+            )
+    except Exception as e:
+        logger.debug(f"trafilatura 失敗: {e}")
+
+    # 2. readability-lxml
+    try:
+        doc = Document(html)
+        summary_html = doc.summary()
+        # HTML タグを除去して本文テキストに
+        text = trafilatura.extract(summary_html) or ""
+        if not text:
+            # trafilatura での再抽出も失敗したら簡易タグ除去
+            import re
+
+            text = re.sub(r"<[^>]+>", " ", summary_html)
+        text = clean_text(text)
+        if count_chars(text) >= 100:
+            input_type = _classify_length(count_chars(text))
+            logger.debug(f"readability で抽出成功: {count_chars(text)} 文字")
+            return ExtractionResult(
+                text=text,
+                method="readability",
+                summary_input_type=input_type,
+                ok=True,
+            )
+    except Exception as e:
+        logger.debug(f"readability 失敗: {e}")
+
+    # 3. メタデータフォールバック
+    fallback = _build_fallback_input(raindrop, og_description)
+    if fallback:
+        logger.debug("メタデータフォールバックを構成")
+        return ExtractionResult(
+            method="metadata",
+            summary_input_type=SummaryInputType.metadata,
+            ok=True,
+            fallback_input=fallback,
+        )
+
+    # 4. すべて失敗
+    logger.debug("本文抽出に完全に失敗")
+    return ExtractionResult()
+
+
+def _classify_length(chars: int) -> SummaryInputType:
+    """文字数に基づいて要約入力タイプを分類する。"""
+    if chars >= 1500:
+        return SummaryInputType.fulltext
+    if chars >= 500:
+        return SummaryInputType.shorttext
+    return SummaryInputType.metadata
+
+
+def _build_fallback_input(raindrop: RaindropItem, og_description: str = "") -> dict:
+    """簡易要約用の入力を構成する。"""
+    parts: dict = {}
+
+    if raindrop.title:
+        parts["title"] = raindrop.title
+    if raindrop.excerpt:
+        parts["excerpt"] = raindrop.excerpt
+    if og_description:
+        parts["og_description"] = og_description
+    if raindrop.url:
+        parts["url"] = raindrop.url
+    if raindrop.domain:
+        parts["domain"] = raindrop.domain
+    if raindrop.tags:
+        parts["tags"] = raindrop.tags
+    if raindrop.created_at:
+        parts["created_at"] = raindrop.created_at.isoformat()
+
+    # タイトルすらなければフォールバック不可
+    if "title" not in parts and "excerpt" not in parts:
+        return {}
+
+    return parts

--- a/src/content_fetcher.py
+++ b/src/content_fetcher.py
@@ -1,0 +1,84 @@
+"""URL から HTML を取得する。"""
+
+import logging
+import re
+
+import httpx
+
+from src.config import Config
+from src.utils.text import is_video_content
+
+logger = logging.getLogger("raindrop_summarizer")
+
+
+class FetchResult:
+    """HTML 取得結果。"""
+
+    def __init__(
+        self,
+        html: str = "",
+        ok: bool = False,
+        error: str = "",
+        og_description: str = "",
+    ) -> None:
+        self.html = html
+        self.ok = ok
+        self.error = error
+        self.og_description = og_description
+
+
+def fetch_url(url: str, config: Config) -> FetchResult:
+    """URL から HTML を取得する。動画 URL はスキップ。"""
+    try:
+        with httpx.Client(
+            timeout=config.request_timeout_seconds,
+            headers={"User-Agent": config.user_agent},
+            follow_redirects=True,
+        ) as client:
+            response = client.get(url)
+            response.raise_for_status()
+
+            content_type = response.headers.get("content-type", "")
+            if "text/html" not in content_type and "application/xhtml" not in content_type:
+                return FetchResult(error=f"非 HTML コンテンツ: {content_type}")
+
+            html = response.text
+            og_desc = _extract_og_description(html)
+
+            return FetchResult(html=html, ok=True, og_description=og_desc)
+
+    except httpx.TimeoutException:
+        return FetchResult(error="タイムアウト")
+    except httpx.HTTPStatusError as e:
+        return FetchResult(error=f"HTTP {e.response.status_code}")
+    except httpx.RequestError as e:
+        return FetchResult(error=f"リクエストエラー: {e}")
+    except Exception as e:
+        return FetchResult(error=f"予期しないエラー: {e}")
+
+
+def should_skip_url(url: str, raindrop_type: str) -> str | None:
+    """スキップすべき URL の理由を返す。スキップ不要なら None。"""
+    if is_video_content(url, raindrop_type):
+        return "unsupported_video"
+    return None
+
+
+def _extract_og_description(html: str) -> str:
+    """HTML から og:description を正規表現で抽出する。"""
+    match = re.search(
+        r'<meta\s+[^>]*property=["\']og:description["\']\s+[^>]*content=["\']([^"\']*)["\']',
+        html,
+        re.IGNORECASE,
+    )
+    if match:
+        return match.group(1).strip()
+    # content が先に来るパターン
+    match = re.search(
+        r'<meta\s+[^>]*content=["\']([^"\']*?)["\']\s+[^>]*property=["\']og:description["\']',
+        html,
+        re.IGNORECASE,
+    )
+    if match:
+        return match.group(1).strip()
+    return ""


### PR DESCRIPTION
Closes #9

## Summary

- `src/content_fetcher.py` — URL からの HTML 取得
  - httpx による HTTP GET（タイムアウト、User-Agent、リダイレクト追跡）
  - 非 HTML コンテンツの検出
  - 動画 URL のスキップ判定
  - og:description の正規表現抽出
- `src/content_extractor.py` — 本文抽出フォールバックチェーン
  - trafilatura → readability-lxml → メタデータフォールバック → スキップ
  - 本文長による要約入力タイプ分類（fulltext / shorttext / metadata）

## Test plan

- [x] `should_skip_url`: YouTube URL → `unsupported_video`、通常 URL → `None`、type=video → `unsupported_video`
- [x] `_extract_og_description`: property→content 順、content→property 順、未設定時の空文字
- [x] `_classify_length`: 1500+→fulltext、500-1499→shorttext、500未満→metadata
- [x] `_build_fallback_input`: 全フィールド構成、タイトル/excerpt なしで空 dict
- [x] `extract_body`: 十分な HTML → trafilatura 抽出成功
- [x] `extract_body`: 空 HTML → メタデータフォールバック

🤖 Generated with [Claude Code](https://claude.com/claude-code)