### PR TITLE
✨ summarizer と要約プロンプトを実装 (#11)

### DIFF
--- a/prompts/summarize_fallback.txt
+++ b/prompts/summarize_fallback.txt
@@ -1,0 +1,36 @@
+あなたは記事要約アシスタントです。以下の記事のメタデータから、日本語で簡易要約を生成してください。
+
+**注意: 本文は取得できていません。メタデータのみに基づく簡易要約です。**
+
+## メタデータ
+
+{metadata}
+
+## 指示
+
+以下の JSON 形式で出力してください。JSON 以外は出力しないでください。
+本文未取得のため、断定的な表現を避け、メタデータから読み取れる範囲で要約してください。
+
+- topic: 推定される主題を1行で
+- summary_3lines: 3行の簡易要約（メタデータから推測できる範囲で）
+- priority: "high" / "medium" / "low"
+- read_now_reason: 今読む価値がある理由（1文）
+- defer_reason: 後回しでよい理由（1文）
+- drop_candidate: true/false
+- drop_reason: ドロップ候補の理由（該当しなければ空文字）
+- keywords: キーワード3〜5個
+
+## 出力例
+
+```json
+{{
+  "topic": "主題",
+  "summary_3lines": ["1行目", "2行目", "3行目"],
+  "priority": "medium",
+  "read_now_reason": "理由",
+  "defer_reason": "理由",
+  "drop_candidate": false,
+  "drop_reason": "",
+  "keywords": ["キーワード1", "キーワード2", "キーワード3"]
+}}
+```

--- a/prompts/summarize_full.txt
+++ b/prompts/summarize_full.txt
@@ -1,0 +1,42 @@
+あなたは記事要約アシスタントです。以下の記事を日本語で要約してください。
+
+## 記事情報
+
+- タイトル: {title}
+- URL: {url}
+- ドメイン: {domain}
+
+## 本文
+
+{text}
+
+## 指示
+
+以下の JSON 形式で出力してください。JSON 以外は出力しないでください。
+
+- topic: 記事の主題を1行で
+- summary_3lines: 3行の要約（各行は簡潔に。感想文ではなく内容紹介。事実不明な断定を避ける）
+- priority: "high" / "medium" / "low"
+  - high: 新規性が高い、関心領域と近い、本文を読む価値がある
+  - medium: 要点把握で十分、時間があれば読む価値がある
+  - low: 重複度が高い、関心軸から遠い、速報性が過ぎている
+- read_now_reason: 今読む価値がある理由（1文）
+- defer_reason: 後回しでよい理由（1文）
+- drop_candidate: true/false（読む価値が薄い場合 true）
+- drop_reason: ドロップ候補の理由（該当しなければ空文字）
+- keywords: 記事のキーワード3〜5個
+
+## 出力例
+
+```json
+{{
+  "topic": "主題",
+  "summary_3lines": ["1行目", "2行目", "3行目"],
+  "priority": "medium",
+  "read_now_reason": "理由",
+  "defer_reason": "理由",
+  "drop_candidate": false,
+  "drop_reason": "",
+  "keywords": ["キーワード1", "キーワード2", "キーワード3"]
+}}
+```

--- a/src/summarizer.py
+++ b/src/summarizer.py
@@ -1,0 +1,152 @@
+"""AI 要約。LLM プロバイダー抽象化 + 要約実行。"""
+
+import json
+import logging
+from pathlib import Path
+from typing import Protocol
+
+from src.config import Config
+from src.models import SummaryResult
+
+logger = logging.getLogger("raindrop_summarizer")
+
+PROMPTS_DIR = Path("prompts")
+
+
+# --- LLM プロバイダー抽象化 ---
+
+
+class LLMProvider(Protocol):
+    def generate(self, prompt: str) -> str: ...
+
+
+class OpenAIProvider:
+    """OpenAI API プロバイダー。"""
+
+    def __init__(self, config: Config) -> None:
+        from openai import OpenAI
+
+        self.client = OpenAI(api_key=config.llm_api_key)
+        self.model = config.llm_model
+
+    def generate(self, prompt: str) -> str:
+        response = self.client.chat.completions.create(
+            model=self.model,
+            messages=[{"role": "user", "content": prompt}],
+            temperature=0.3,
+            response_format={"type": "json_object"},
+        )
+        return response.choices[0].message.content or ""
+
+
+class GeminiProvider:
+    """Google Gemini API プロバイダー。"""
+
+    def __init__(self, config: Config) -> None:
+        import google.generativeai as genai
+
+        genai.configure(api_key=config.llm_api_key)
+        self.model = genai.GenerativeModel(config.llm_model)
+
+    def generate(self, prompt: str) -> str:
+        response = self.model.generate_content(prompt)
+        return response.text or ""
+
+
+class AnthropicProvider:
+    """Anthropic API プロバイダー。"""
+
+    def __init__(self, config: Config) -> None:
+        from anthropic import Anthropic
+
+        self.client = Anthropic(api_key=config.llm_api_key)
+        self.model = config.llm_model
+
+    def generate(self, prompt: str) -> str:
+        response = self.client.messages.create(
+            model=self.model,
+            max_tokens=1024,
+            messages=[{"role": "user", "content": prompt}],
+        )
+        return response.content[0].text if response.content else ""
+
+
+def create_provider(config: Config) -> LLMProvider:
+    """Config に基づき LLM プロバイダーを生成する。"""
+    match config.llm_provider:
+        case "openai":
+            return OpenAIProvider(config)
+        case "gemini":
+            return GeminiProvider(config)
+        case "anthropic":
+            return AnthropicProvider(config)
+        case _:
+            raise ValueError(f"未対応の LLM プロバイダー: {config.llm_provider}")
+
+
+# --- プロンプト読み込み ---
+
+
+def _load_prompt(name: str) -> str:
+    """prompts/ からプロンプトテンプレートを読み込む。"""
+    path = PROMPTS_DIR / name
+    return path.read_text(encoding="utf-8")
+
+
+# --- 要約実行 ---
+
+
+def summarize_fulltext(
+    provider: LLMProvider,
+    text: str,
+    title: str = "",
+    url: str = "",
+    domain: str = "",
+) -> SummaryResult | None:
+    """本文全文から要約を生成する。"""
+    template = _load_prompt("summarize_full.txt")
+    prompt = template.format(title=title, url=url, domain=domain, text=text)
+    return _call_and_parse(provider, prompt)
+
+
+def summarize_fallback(
+    provider: LLMProvider,
+    fallback_input: dict,
+) -> SummaryResult | None:
+    """メタデータから簡易要約を生成する。"""
+    template = _load_prompt("summarize_fallback.txt")
+    metadata_str = json.dumps(fallback_input, ensure_ascii=False, indent=2)
+    prompt = template.format(metadata=metadata_str)
+    return _call_and_parse(provider, prompt)
+
+
+def _call_and_parse(provider: LLMProvider, prompt: str) -> SummaryResult | None:
+    """LLM を呼び出し、レスポンスを SummaryResult にパースする。リトライ 1 回。"""
+    for attempt in range(2):
+        try:
+            raw = provider.generate(prompt)
+            return _parse_response(raw)
+        except Exception as e:
+            if attempt == 0:
+                logger.warning(f"LLM 呼び出し/パース失敗、リトライします: {e}")
+            else:
+                logger.error(f"LLM 呼び出し/パース失敗（リトライ後）: {e}")
+    return None
+
+
+def _parse_response(raw: str) -> SummaryResult:
+    """LLM レスポンスから JSON を抽出し SummaryResult にパースする。"""
+    text = raw.strip()
+
+    # ```json ... ``` で囲まれている場合
+    if "```json" in text:
+        start = text.index("```json") + 7
+        end = text.index("```", start)
+        text = text[start:end].strip()
+    elif "```" in text:
+        start = text.index("```") + 3
+        end = text.index("```", start)
+        text = text[start:end].strip()
+
+    data = json.loads(text)
+    return SummaryResult.model_validate(data)


### PR DESCRIPTION
Closes #11

## Summary

- `src/summarizer.py` — LLM プロバイダー抽象化と要約実行
  - `LLMProvider` Protocol + Factory パターン（OpenAI / Gemini / Anthropic）
  - `summarize_fulltext()`: 本文全文から日本語要約を生成
  - `summarize_fallback()`: メタデータのみから簡易要約を生成
  - JSON レスポンスパース（コードブロック `\`\`\`json` 対応）
  - リトライ 1 回付き
- `prompts/summarize_full.txt` — 本文全文用プロンプト
- `prompts/summarize_fallback.txt` — メタデータのみ用プロンプト（本文未取得前提を明示）

## Test plan

- [x] プロンプトファイルの読み込みとテンプレート変数の存在確認
- [x] `_parse_response`: 正常な JSON → `SummaryResult` にパース
- [x] `_parse_response`: `\`\`\`json` コードブロック付き JSON もパース可能
- [x] `summarize_fulltext`: モック LLM で要約結果が正しく返る
- [x] `summarize_fallback`: モック LLM で簡易要約が正しく返る
- [x] `create_provider`: 未対応プロバイダーで `ValueError`

🤖 Generated with [Claude Code](https://claude.com/claude-code)