### PR TITLE
✨ html_builder と HTML テンプレート・CSS・JS を実装 (#13)

### DIFF
--- a/docs/app.js
+++ b/docs/app.js
@@ -1,0 +1,22 @@
+// 優先度フィルタ
+document.addEventListener("DOMContentLoaded", () => {
+  const buttons = document.querySelectorAll(".filter-btn");
+  const cards = document.querySelectorAll(".card");
+
+  buttons.forEach((btn) => {
+    btn.addEventListener("click", () => {
+      const filter = btn.dataset.filter;
+
+      buttons.forEach((b) => b.classList.remove("active"));
+      btn.classList.add("active");
+
+      cards.forEach((card) => {
+        if (filter === "all" || card.dataset.priority === filter) {
+          card.style.display = "";
+        } else {
+          card.style.display = "none";
+        }
+      });
+    });
+  });
+});

--- a/docs/styles.css
+++ b/docs/styles.css
@@ -1,0 +1,247 @@
+* {
+  margin: 0;
+  padding: 0;
+  box-sizing: border-box;
+}
+
+body {
+  font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, "Hiragino Sans", sans-serif;
+  background: #f5f5f5;
+  color: #333;
+  line-height: 1.6;
+  padding: 20px;
+  max-width: 960px;
+  margin: 0 auto;
+}
+
+header {
+  margin-bottom: 24px;
+}
+
+h1 {
+  font-size: 1.5rem;
+  margin-bottom: 8px;
+}
+
+.stats {
+  display: flex;
+  gap: 16px;
+  font-size: 0.85rem;
+  color: #666;
+  margin-bottom: 12px;
+  flex-wrap: wrap;
+}
+
+.filters {
+  display: flex;
+  gap: 8px;
+  margin-bottom: 8px;
+}
+
+.filter-btn {
+  padding: 4px 12px;
+  border: 1px solid #ccc;
+  border-radius: 4px;
+  background: #fff;
+  cursor: pointer;
+  font-size: 0.85rem;
+}
+
+.filter-btn.active {
+  background: #333;
+  color: #fff;
+  border-color: #333;
+}
+
+/* Cards */
+
+.card {
+  background: #fff;
+  border-radius: 8px;
+  padding: 16px;
+  margin-bottom: 12px;
+  border-left: 4px solid #ccc;
+  box-shadow: 0 1px 3px rgba(0, 0, 0, 0.08);
+}
+
+.card.priority-high {
+  border-left-color: #e53e3e;
+}
+
+.card.priority-medium {
+  border-left-color: #d69e2e;
+}
+
+.card.priority-low {
+  border-left-color: #a0aec0;
+  opacity: 0.85;
+}
+
+.card-header {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  font-size: 0.8rem;
+  color: #888;
+  margin-bottom: 6px;
+}
+
+.priority-badge {
+  padding: 2px 8px;
+  border-radius: 3px;
+  font-size: 0.7rem;
+  font-weight: bold;
+  color: #fff;
+}
+
+.priority-badge.priority-high {
+  background: #e53e3e;
+}
+
+.priority-badge.priority-medium {
+  background: #d69e2e;
+}
+
+.priority-badge.priority-low {
+  background: #a0aec0;
+}
+
+.card-title {
+  font-size: 1.05rem;
+  margin-bottom: 6px;
+}
+
+.card-title a {
+  color: #1a202c;
+  text-decoration: none;
+}
+
+.card-title a:hover {
+  text-decoration: underline;
+}
+
+.topic {
+  font-size: 0.9rem;
+  color: #555;
+  margin-bottom: 8px;
+  font-weight: 500;
+}
+
+.summary {
+  list-style: disc inside;
+  font-size: 0.9rem;
+  margin-bottom: 8px;
+  padding-left: 4px;
+}
+
+.summary li {
+  margin-bottom: 2px;
+}
+
+.reasons {
+  font-size: 0.82rem;
+  margin-bottom: 8px;
+}
+
+.reason {
+  margin-bottom: 2px;
+}
+
+.reason-label {
+  font-weight: 600;
+}
+
+.reason.drop {
+  color: #e53e3e;
+}
+
+.keywords {
+  display: flex;
+  gap: 6px;
+  flex-wrap: wrap;
+  margin-bottom: 8px;
+}
+
+.keyword {
+  background: #edf2f7;
+  padding: 2px 8px;
+  border-radius: 3px;
+  font-size: 0.75rem;
+  color: #4a5568;
+}
+
+.card-footer {
+  display: flex;
+  gap: 12px;
+  font-size: 0.75rem;
+  color: #aaa;
+}
+
+/* Skipped section */
+
+.skipped-section {
+  margin-top: 32px;
+}
+
+.skipped-section h2 {
+  font-size: 1.1rem;
+  margin-bottom: 12px;
+  color: #888;
+}
+
+.skipped-item {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  padding: 8px 0;
+  border-bottom: 1px solid #eee;
+  font-size: 0.85rem;
+}
+
+.skipped-item a {
+  color: #555;
+  text-decoration: none;
+}
+
+.skipped-item a:hover {
+  text-decoration: underline;
+}
+
+.badge {
+  padding: 2px 6px;
+  border-radius: 3px;
+  font-size: 0.7rem;
+}
+
+.badge.video {
+  background: #fef3c7;
+  color: #92400e;
+}
+
+.badge.skip-reason {
+  background: #fee2e2;
+  color: #991b1b;
+}
+
+.empty {
+  text-align: center;
+  color: #aaa;
+  padding: 40px;
+}
+
+/* Responsive */
+
+@media (max-width: 600px) {
+  body {
+    padding: 12px;
+  }
+
+  .card {
+    padding: 12px;
+  }
+
+  .stats {
+    flex-direction: column;
+    gap: 4px;
+  }
+}

--- a/src/html_builder.py
+++ b/src/html_builder.py
@@ -1,0 +1,53 @@
+"""HTML 出力。Jinja2 テンプレートで docs/index.html を生成する。"""
+
+import logging
+from pathlib import Path
+
+from jinja2 import Environment, FileSystemLoader
+
+from src.models import ArticleState, Priority, ProcessedArticle
+from src.utils.time import format_display
+
+logger = logging.getLogger("raindrop_summarizer")
+
+TEMPLATE_DIR = Path(__file__).parent / "templates"
+
+
+class HtmlBuilder:
+    """記事一覧の HTML を生成する。"""
+
+    def __init__(self, output_dir: str = "docs") -> None:
+        self.output_dir = Path(output_dir)
+        self.env = Environment(
+            loader=FileSystemLoader(str(TEMPLATE_DIR)),
+            autoescape=True,
+        )
+
+    def build(self, articles: list[ProcessedArticle], last_run_at: str = "") -> Path:
+        """記事一覧 HTML を生成する。"""
+        self.output_dir.mkdir(parents=True, exist_ok=True)
+
+        # 要約済みとスキップ/失敗を分離
+        summarized = [a for a in articles if a.summary_3lines]
+        skipped = [a for a in articles if not a.summary_3lines]
+
+        # ソート: priority (high→medium→low) → created_at 新しい順
+        priority_order = {Priority.high: 0, Priority.medium: 1, Priority.low: 2}
+        summarized.sort(key=lambda a: (priority_order.get(a.priority, 1), -a.created_at.timestamp()))
+
+        template = self.env.get_template("index.html")
+        html = template.render(
+            articles=summarized,
+            skipped=skipped,
+            total=len(articles),
+            summarized_count=len(summarized),
+            skipped_count=len(skipped),
+            last_run_at=last_run_at,
+            format_display=format_display,
+            Priority=Priority,
+        )
+
+        path = self.output_dir / "index.html"
+        path.write_text(html, encoding="utf-8")
+        logger.info(f"HTML を生成: {path} (要約 {len(summarized)} 件, スキップ {len(skipped)} 件)")
+        return path

--- a/src/templates/index.html
+++ b/src/templates/index.html
@@ -1,0 +1,112 @@
+<!DOCTYPE html>
+<html lang="ja">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Raindrop Collection Summary</title>
+  <link rel="stylesheet" href="styles.css">
+</head>
+<body>
+  <header>
+    <h1>Raindrop Collection Summary</h1>
+    <div class="stats">
+      <span>総記事数: {{ total }}</span>
+      <span>要約済み: {{ summarized_count }}</span>
+      <span>スキップ: {{ skipped_count }}</span>
+      {% if last_run_at %}<span>最終実行: {{ last_run_at }}</span>{% endif %}
+    </div>
+    <div class="filters">
+      <button class="filter-btn active" data-filter="all">すべて</button>
+      <button class="filter-btn" data-filter="high">High</button>
+      <button class="filter-btn" data-filter="medium">Medium</button>
+      <button class="filter-btn" data-filter="low">Low</button>
+    </div>
+  </header>
+
+  <main>
+    {% if articles %}
+    <section class="articles">
+      {% for article in articles %}
+      <article class="card priority-{{ article.priority.value }}" data-priority="{{ article.priority.value }}">
+        <div class="card-header">
+          <span class="priority-badge priority-{{ article.priority.value }}">{{ article.priority.value | upper }}</span>
+          <span class="domain">{{ article.domain }}</span>
+          <span class="date">{{ format_display(article.created_at) }}</span>
+        </div>
+
+        <h2 class="card-title">
+          <a href="{{ article.url }}" target="_blank" rel="noopener">{{ article.title }}</a>
+        </h2>
+
+        {% if article.topic %}
+        <p class="topic">{{ article.topic }}</p>
+        {% endif %}
+
+        {% if article.summary_3lines %}
+        <ul class="summary">
+          {% for line in article.summary_3lines %}
+          <li>{{ line }}</li>
+          {% endfor %}
+        </ul>
+        {% endif %}
+
+        <div class="reasons">
+          {% if article.read_now_reason %}
+          <div class="reason read-now">
+            <span class="reason-label">今読む理由:</span> {{ article.read_now_reason }}
+          </div>
+          {% endif %}
+          {% if article.defer_reason %}
+          <div class="reason defer">
+            <span class="reason-label">後回し理由:</span> {{ article.defer_reason }}
+          </div>
+          {% endif %}
+          {% if article.drop_candidate %}
+          <div class="reason drop">
+            <span class="reason-label">ドロップ候補:</span> {{ article.drop_reason if article.drop_reason else "該当" }}
+          </div>
+          {% endif %}
+        </div>
+
+        {% if article.keywords %}
+        <div class="keywords">
+          {% for kw in article.keywords %}
+          <span class="keyword">{{ kw }}</span>
+          {% endfor %}
+        </div>
+        {% endif %}
+
+        <div class="card-footer">
+          <span class="status">取得: {{ article.fetch_status if article.fetch_status else "-" }}</span>
+          <span class="status">手動: {{ article.manual_status.value }}</span>
+          {% if article.summary_input_type %}
+          <span class="status">入力: {{ article.summary_input_type.value }}</span>
+          {% endif %}
+        </div>
+      </article>
+      {% endfor %}
+    </section>
+    {% else %}
+    <p class="empty">要約済みの記事はありません。</p>
+    {% endif %}
+
+    {% if skipped %}
+    <section class="skipped-section">
+      <h2>スキップ・未処理 ({{ skipped_count }} 件)</h2>
+      {% for article in skipped %}
+      <div class="skipped-item">
+        <a href="{{ article.url }}" target="_blank" rel="noopener">{{ article.title if article.title else article.url }}</a>
+        <span class="domain">{{ article.domain }}</span>
+        {% if article.content_type.value == "video" %}
+        <span class="badge video">動画</span>
+        {% endif %}
+        <span class="badge skip-reason">{{ article.content_status if article.content_status else "未処理" }}</span>
+      </div>
+      {% endfor %}
+    </section>
+    {% endif %}
+  </main>
+
+  <script src="app.js"></script>
+</body>
+</html>


### PR DESCRIPTION
Closes #13

## Summary

- `src/html_builder.py` — Jinja2 テンプレートで `docs/index.html` を生成
  - 優先度（high→medium→low）→ created_at 新しい順のソート
  - 要約済み / スキップの分離表示
  - 統計情報（総記事数、要約済み、スキップ、最終実行日時）
- `src/templates/index.html` — 記事カード、フィルタボタン、スキップセクション
- `docs/styles.css` — 優先度ごとの色分け（赤/黄/灰）、カード形式レスポンシブレイアウト
- `docs/app.js` — 優先度フィルタのクライアントサイド絞り込み

## Test plan

- [x] 4件（high/medium/low/スキップ）の記事で HTML 生成
- [x] 基本構造（DOCTYPE、タイトル、統計情報）の確認
- [x] ソート順: high → medium → low の順に表示
- [x] ドロップ候補の理由が表示される
- [x] スキップセクションに動画記事が表示される
- [x] フィルタボタンが存在する

🤖 Generated with [Claude Code](https://claude.com/claude-code)