### PR TITLE
📚 README に API キー取得手順とセットアップ詳細を追記 (#19)

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,50 +21,143 @@ cd raindrop-collection-summarizer
 
 ### 2. Python 環境を用意
 
-Python 3.11 以上が必要です。
+Python 3.11 以上が必要です。[uv](https://docs.astral.sh/uv/) を使うと Python ごとインストールできます。
 
 ```bash
+# uv を使う場合（推奨）
+uv venv --python 3.11
+source .venv/bin/activate
+uv pip install -e ".[dev]"
+
+# pip を使う場合
 python -m venv .venv
 source .venv/bin/activate
 pip install -e ".[dev]"
 ```
 
-### 3. 環境変数を設定
+### 3. API キーの取得
+
+このツールの実行には **Raindrop.io API トークン** と **LLM API キー** の 2 つが必要です。
+
+#### Raindrop.io テストトークン
+
+1. [Raindrop.io Integrations](https://app.raindrop.io/settings/integrations) にアクセス
+2. 「For Developers」セクションの **Create new app** をクリック
+3. アプリ名を入力（例: `RaindropSummarizer`）して作成
+4. 作成したアプリをクリック → **Create test token** をクリック
+5. 表示されたトークンをコピー
+
+#### コレクション ID の確認
+
+1. [Raindrop.io](https://app.raindrop.io) にアクセス
+2. 対象のコレクション（「あとで読む」等）を開く
+3. URL を確認: `https://app.raindrop.io/my/{collection_id}` — この数値部分がコレクション ID
+
+#### LLM API キー
+
+以下のいずれか 1 つのプロバイダーの API キーを取得します。
+
+**Google Gemini（推奨・無料枠あり）**
+
+1. [Google AI Studio](https://aistudio.google.com/apikey) にアクセス
+2. **Create API Key** → **Create API key in new project** を選択
+3. API キーが発行される
+4. 推奨モデル: `gemini-2.5-flash`
+
+> Google Cloud の請求先アカウントの紐づけと [Gemini API の有効化](https://console.cloud.google.com/apis/library/generativelanguage.googleapis.com) が必要な場合があります。
+
+**OpenAI**
+
+1. [OpenAI API Keys](https://platform.openai.com/api-keys) にアクセス
+2. **Create new secret key** でキーを生成
+3. 推奨モデル: `gpt-4.1-mini`
+
+**Anthropic**
+
+1. [Anthropic Console](https://console.anthropic.com/settings/keys) にアクセス
+2. **Create Key** でキーを生成
+3. 推奨モデル: `claude-haiku-4-5-20251001`
+
+### 4. 環境変数の設定
 
 ```bash
 cp .env.example .env
-# .env を編集して API キーなどを設定
 ```
 
-必要な環境変数:
-- `RAINDROP_TOKEN`: Raindrop.io API テストトークン
-- `RAINDROP_COLLECTION_ID`: 対象コレクション ID
-- `LLM_PROVIDER`: `openai` / `gemini` / `anthropic`
-- `LLM_API_KEY`: LLM の API キー
-- `LLM_MODEL`: 使用するモデル名
+`.env` を開いて取得したキーを設定します:
+
+```env
+RAINDROP_TOKEN=your-raindrop-token
+RAINDROP_COLLECTION_ID=your-collection-id
+LLM_PROVIDER=gemini
+LLM_API_KEY=your-llm-api-key
+LLM_MODEL=gemini-2.5-flash
+```
+
+> `.env` は `.gitignore` に含まれているため、リポジトリにコミットされません。
+
+### 5. 動作確認
+
+```bash
+# まず Raindrop API の接続だけ確認（LLM 不要）
+python -m src fetch-only
+
+# 少数で要約を試す
+MAX_SUMMARIZE_PER_RUN=3 python -m src run
+
+# 問題なければフル実行
+python -m src run
+```
 
 ## 使い方
 
 ```bash
 # フルパイプライン実行（取得 → 抽出 → 要約 → HTML 生成）
-python -m src.main run
+python -m src run
+
+# 対象記事を確認だけ（処理はしない）
+python -m src run --dry-run
+
+# 詳細ログ付き実行
+python -m src run --verbose
 
 # Raindrop 取得のみ
-python -m src.main fetch-only
+python -m src fetch-only
 
 # HTML 再生成
-python -m src.main build-html
+python -m src build-html
 
 # 特定記事の再処理
-python -m src.main reprocess --id 123456789
+python -m src reprocess --id 123456789
 
 # 失敗記事の一括再試行
-python -m src.main reprocess-failed
+python -m src reprocess-failed
 ```
 
 ## 出力
 
 `docs/index.html` に記事一覧が生成されます。ブラウザで開いて確認できます。
+
+- 優先度ごとに色分け（HIGH=赤 / MEDIUM=黄 / LOW=灰）
+- フィルタボタンで優先度別に絞り込み可能
+- 各記事に 3 行要約・今読む理由・後回し理由・キーワードを表示
+
+## 設定
+
+| 環境変数 | 説明 | デフォルト |
+|---|---|---|
+| `RAINDROP_TOKEN` | Raindrop.io API テストトークン | （必須） |
+| `RAINDROP_COLLECTION_ID` | 対象コレクション ID | （必須） |
+| `LLM_PROVIDER` | `openai` / `gemini` / `anthropic` | `openai` |
+| `LLM_API_KEY` | LLM の API キー | （必須） |
+| `LLM_MODEL` | 使用するモデル名 | （必須） |
+| `MAX_SUMMARIZE_PER_RUN` | 1 回の要約件数上限 | `30` |
+| `REQUEST_TIMEOUT_SECONDS` | HTTP リクエストタイムアウト | `20` |
+| `USER_AGENT` | HTTP リクエストの User-Agent | `RaindropSummarizer/0.1` |
+| `OUTPUT_DIR` | HTML 出力先ディレクトリ | `docs` |
+| `DATA_DIR` | データ保存ディレクトリ | `data` |
+| `STATE_DIR` | 状態管理ディレクトリ | `state` |
+| `LOG_LEVEL` | ログレベル | `INFO` |
 
 ## テスト
 


### PR DESCRIPTION
Closes #19

## Summary

- Raindrop.io テストトークンの取得手順（スクリーンショット不要な手順ベース）
- コレクション ID の確認方法（URL から読み取り）
- LLM API キーの取得手順（Gemini 推奨 / OpenAI / Anthropic の 3 プロバイダー）
- Google AI Studio でのプロジェクト作成・請求設定・API 有効化の注意事項
- `.env` の設定例と `.gitignore` 済みである旨の注記
- 段階的な動作確認手順（`fetch-only` → 少数実行 → フル実行）
- 全環境変数の一覧表（説明・デフォルト値付き）
- uv を使ったセットアップ手順を追加

## Test plan

- [x] README の手順に沿って実際にセットアップ・実行できることを確認済み

🤖 Generated with [Claude Code](https://claude.com/claude-code)