### PR TITLE
♻️ google-genai SDK へ移行 (#23)

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -14,7 +14,7 @@ dependencies = [
     "rich>=13.0",
     "click>=8.1",
     "openai>=1.0",
-    "google-generativeai>=0.5",
+    "google-genai>=1.0",
     "anthropic>=0.30",
 ]
 

--- a/src/summarizer.py
+++ b/src/summarizer.py
@@ -43,13 +43,16 @@ class GeminiProvider:
     """Google Gemini API プロバイダー。"""
 
     def __init__(self, config: Config) -> None:
-        import google.generativeai as genai
+        from google import genai
 
-        genai.configure(api_key=config.llm_api_key)
-        self.model = genai.GenerativeModel(config.llm_model)
+        self.client = genai.Client(api_key=config.llm_api_key)
+        self.model_name = config.llm_model
 
     def generate(self, prompt: str) -> str:
-        response = self.model.generate_content(prompt)
+        response = self.client.models.generate_content(
+            model=self.model_name,
+            contents=prompt,
+        )
         return response.text or ""
 
 


### PR DESCRIPTION
Closes #23

## Summary

- `pyproject.toml`: `google-generativeai` → `google-genai>=1.0` に変更
- `src/summarizer.py`: `GeminiProvider` を新 SDK の `genai.Client` ベースに書き換え

## Test plan

- [x] `pytest` 65 テスト全パス
- [x] 実 API で 1 件要約成功、`FutureWarning` が解消されたことを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)