### PR TITLE
⚡ エラーハンドリング強化 (#25)

### DIFF
--- a/src/main.py
+++ b/src/main.py
@@ -1,6 +1,11 @@
 """CLI エントリポイント。全モジュールを統合するオーケストレーション層。"""
 
 import logging
+import time
+import warnings
+
+# requests の RequestsDependencyWarning を抑制
+warnings.filterwarnings("ignore", message="urllib3.*doesn't match a supported version")
 
 import click
 from rich.console import Console
@@ -95,6 +100,10 @@ def run(dry_run: bool, verbose: bool) -> None:
             logger.error(f"記事処理エラー ({raindrop.raindrop_id}): {e}")
             state.update_status(raindrop.raindrop_id, ArticleState.failed, reason=str(e))
             stats["failed"] += 1
+
+        # レートリミット対策: 記事間に 2 秒待機
+        if i < len(targets):
+            time.sleep(2)
 
     state.mark_run_completed()
     state.save()
@@ -280,7 +289,8 @@ def _process_article(
             content_status="fetch_failed",
         )
         repo.save(article)
-        state.update_status(rid, ArticleState.skipped, reason="fetch_failed")
+        reason = f"fetch_failed: {fetch_result.error}"
+        state.update_status(rid, ArticleState.skipped, reason=reason)
         logger.warning(f"取得失敗: {raindrop.title} - {fetch_result.error}")
         return article
 

--- a/src/summarizer.py
+++ b/src/summarizer.py
@@ -124,14 +124,17 @@ def summarize_fallback(
 
 
 def _call_and_parse(provider: LLMProvider, prompt: str) -> SummaryResult | None:
-    """LLM を呼び出し、レスポンスを SummaryResult にパースする。リトライ 1 回。"""
+    """LLM を呼び出し、レスポンスを SummaryResult にパースする。リトライ 1 回（待機付き）。"""
+    import time
+
     for attempt in range(2):
         try:
             raw = provider.generate(prompt)
             return _parse_response(raw)
         except Exception as e:
             if attempt == 0:
-                logger.warning(f"LLM 呼び出し/パース失敗、リトライします: {e}")
+                logger.warning(f"LLM 呼び出し/パース失敗、5秒後にリトライします: {e}")
+                time.sleep(5)
             else:
                 logger.error(f"LLM 呼び出し/パース失敗（リトライ後）: {e}")
     return None


### PR DESCRIPTION
Closes #25

## Summary

- 記事間に 2 秒の待機を追加（LLM レートリミット対策）
- LLM リトライ時に 5 秒の待機を追加（即リトライによる連続失敗を防止）
- 失敗理由をより具体的に state に記録（`fetch_failed: HTTP 403` 等）
- `requests` の `RequestsDependencyWarning` を `warnings.filterwarnings` で抑制

## Test plan

- [x] `pytest` 65 テスト全パス
- [x] 実 API で 2 件処理。警告なし、記事間待機あり、成功

🤖 Generated with [Claude Code](https://claude.com/claude-code)