### PR TITLE
✨ HTML デザイン改善 (#29)

### DIFF
--- a/docs/app.js
+++ b/docs/app.js
@@ -1,4 +1,3 @@
-// 優先度フィルタ
 document.addEventListener("DOMContentLoaded", () => {
   const buttons = document.querySelectorAll(".filter-btn");
   const cards = document.querySelectorAll(".card");

--- a/docs/styles.css
+++ b/docs/styles.css
@@ -45,6 +45,11 @@ h1 {
   background: #fff;
   cursor: pointer;
   font-size: 0.85rem;
+  transition: background 0.15s, color 0.15s;
+}
+
+.filter-btn:hover {
+  background: #eee;
 }
 
 .filter-btn.active {
@@ -58,10 +63,15 @@ h1 {
 .card {
   background: #fff;
   border-radius: 8px;
-  padding: 16px;
+  padding: 16px 20px;
   margin-bottom: 12px;
   border-left: 4px solid #ccc;
   box-shadow: 0 1px 3px rgba(0, 0, 0, 0.08);
+  transition: box-shadow 0.15s;
+}
+
+.card:hover {
+  box-shadow: 0 2px 8px rgba(0, 0, 0, 0.12);
 }
 
 .card.priority-high {
@@ -75,6 +85,11 @@ h1 {
 .card.priority-low {
   border-left-color: #a0aec0;
   opacity: 0.85;
+}
+
+.card.drop-candidate {
+  opacity: 0.6;
+  border-left-style: dashed;
 }
 
 .card-header {
@@ -106,6 +121,15 @@ h1 {
   background: #a0aec0;
 }
 
+.drop-badge {
+  padding: 2px 8px;
+  border-radius: 3px;
+  font-size: 0.7rem;
+  font-weight: bold;
+  background: #fed7d7;
+  color: #c53030;
+}
+
 .card-title {
   font-size: 1.05rem;
   margin-bottom: 6px;
@@ -120,31 +144,43 @@ h1 {
   text-decoration: underline;
 }
 
-.topic {
-  font-size: 0.9rem;
-  color: #555;
-  margin-bottom: 8px;
-  font-weight: 500;
-}
-
 .summary {
   list-style: disc inside;
   font-size: 0.9rem;
-  margin-bottom: 8px;
+  margin-bottom: 10px;
   padding-left: 4px;
 }
 
 .summary li {
-  margin-bottom: 2px;
+  margin-bottom: 3px;
+}
+
+/* Reasons toggle */
+
+.reasons-toggle {
+  margin-bottom: 10px;
+}
+
+.reasons-toggle summary {
+  cursor: pointer;
+  font-size: 0.82rem;
+  color: #888;
+  user-select: none;
+}
+
+.reasons-toggle summary:hover {
+  color: #555;
 }
 
 .reasons {
   font-size: 0.82rem;
-  margin-bottom: 8px;
+  margin-top: 6px;
+  padding-left: 12px;
+  border-left: 2px solid #e2e8f0;
 }
 
 .reason {
-  margin-bottom: 2px;
+  margin-bottom: 3px;
 }
 
 .reason-label {
@@ -183,10 +219,12 @@ h1 {
   margin-top: 32px;
 }
 
-.skipped-section h2 {
+.skipped-section summary {
+  cursor: pointer;
   font-size: 1.1rem;
-  margin-bottom: 12px;
   color: #888;
+  font-weight: 600;
+  user-select: none;
 }
 
 .skipped-item {
@@ -253,15 +291,80 @@ footer a:hover {
 
 @media (max-width: 600px) {
   body {
-    padding: 12px;
+    padding: 10px;
+    font-size: 15px;
   }
 
-  .card {
-    padding: 12px;
+  h1 {
+    font-size: 1.3rem;
   }
 
   .stats {
     flex-direction: column;
     gap: 4px;
+    font-size: 0.8rem;
+  }
+
+  .filters {
+    flex-wrap: wrap;
+    gap: 6px;
+  }
+
+  .filter-btn {
+    padding: 6px 14px;
+    font-size: 0.9rem;
+  }
+
+  .card {
+    padding: 14px;
+    margin-bottom: 10px;
+  }
+
+  .card-header {
+    flex-wrap: wrap;
+    gap: 6px;
+  }
+
+  .card-title {
+    font-size: 1rem;
+    line-height: 1.5;
+  }
+
+  .summary {
+    font-size: 0.88rem;
+    line-height: 1.7;
+    padding-left: 2px;
+  }
+
+  .summary li {
+    margin-bottom: 6px;
+  }
+
+  .keywords {
+    gap: 5px;
+  }
+
+  .keyword {
+    font-size: 0.78rem;
+    padding: 3px 8px;
+  }
+
+  .reasons-toggle summary {
+    font-size: 0.85rem;
+    padding: 4px 0;
+  }
+
+  .reasons {
+    font-size: 0.85rem;
+    line-height: 1.6;
+  }
+
+  .skipped-item {
+    flex-wrap: wrap;
+    gap: 4px;
+  }
+
+  footer {
+    font-size: 0.8rem;
   }
 }

--- a/src/templates/index.html
+++ b/src/templates/index.html
@@ -10,9 +10,7 @@
   <header>
     <h1>Raindrop Collection Summary</h1>
     <div class="stats">
-      <span>総記事数: {{ total }}</span>
-      <span>要約済み: {{ summarized_count }}</span>
-      <span>スキップ: {{ skipped_count }}</span>
+      <span>{{ total }} 件</span>
       {% if last_run_at %}<span>最終実行: {{ last_run_at }}</span>{% endif %}
     </div>
     <div class="filters">
@@ -27,9 +25,10 @@
     {% if articles %}
     <section class="articles">
       {% for article in articles %}
-      <article class="card priority-{{ article.priority.value }}" data-priority="{{ article.priority.value }}">
+      <article class="card priority-{{ article.priority.value }}{% if article.drop_candidate %} drop-candidate{% endif %}" data-priority="{{ article.priority.value }}">
         <div class="card-header">
           <span class="priority-badge priority-{{ article.priority.value }}">{{ article.priority.value | upper }}</span>
+          {% if article.drop_candidate %}<span class="drop-badge">DROP</span>{% endif %}
           <span class="domain">{{ article.domain }}</span>
           <span class="date">{{ format_display(article.created_at) }}</span>
         </div>
@@ -37,10 +36,6 @@
         <h2 class="card-title">
           <a href="{{ article.url }}" target="_blank" rel="noopener">{{ article.title }}</a>
         </h2>
-
-        {% if article.topic %}
-        <p class="topic">{{ article.topic }}</p>
-        {% endif %}
 
         {% if article.summary_3lines %}
         <ul class="summary">
@@ -50,23 +45,26 @@
         </ul>
         {% endif %}
 
-        <div class="reasons">
-          {% if article.read_now_reason %}
-          <div class="reason read-now">
-            <span class="reason-label">今読む理由:</span> {{ article.read_now_reason }}
+        <details class="reasons-toggle">
+          <summary>判定理由</summary>
+          <div class="reasons">
+            {% if article.read_now_reason %}
+            <div class="reason read-now">
+              <span class="reason-label">今読む理由:</span> {{ article.read_now_reason }}
+            </div>
+            {% endif %}
+            {% if article.defer_reason %}
+            <div class="reason defer">
+              <span class="reason-label">後回し理由:</span> {{ article.defer_reason }}
+            </div>
+            {% endif %}
+            {% if article.drop_candidate %}
+            <div class="reason drop">
+              <span class="reason-label">ドロップ理由:</span> {{ article.drop_reason if article.drop_reason else "該当" }}
+            </div>
+            {% endif %}
           </div>
-          {% endif %}
-          {% if article.defer_reason %}
-          <div class="reason defer">
-            <span class="reason-label">後回し理由:</span> {{ article.defer_reason }}
-          </div>
-          {% endif %}
-          {% if article.drop_candidate %}
-          <div class="reason drop">
-            <span class="reason-label">ドロップ候補:</span> {{ article.drop_reason if article.drop_reason else "該当" }}
-          </div>
-          {% endif %}
-        </div>
+        </details>
 
         {% if article.keywords %}
         <div class="keywords">
@@ -76,13 +74,6 @@
         </div>
         {% endif %}
 
-        <div class="card-footer">
-          <span class="status">取得: {{ article.fetch_status if article.fetch_status else "-" }}</span>
-          <span class="status">手動: {{ article.manual_status.value }}</span>
-          {% if article.summary_input_type %}
-          <span class="status">入力: {{ article.summary_input_type.value }}</span>
-          {% endif %}
-        </div>
       </article>
       {% endfor %}
     </section>
@@ -92,17 +83,19 @@
 
     {% if skipped %}
     <section class="skipped-section">
-      <h2>スキップ・未処理 ({{ skipped_count }} 件)</h2>
-      {% for article in skipped %}
-      <div class="skipped-item">
-        <a href="{{ article.url }}" target="_blank" rel="noopener">{{ article.title if article.title else article.url }}</a>
-        <span class="domain">{{ article.domain }}</span>
-        {% if article.content_type.value == "video" %}
-        <span class="badge video">動画</span>
-        {% endif %}
-        <span class="badge skip-reason">{{ article.content_status if article.content_status else "未処理" }}</span>
-      </div>
-      {% endfor %}
+      <details>
+        <summary>スキップ・未処理 ({{ skipped_count }} 件)</summary>
+        {% for article in skipped %}
+        <div class="skipped-item">
+          <a href="{{ article.url }}" target="_blank" rel="noopener">{{ article.title if article.title else article.url }}</a>
+          <span class="domain">{{ article.domain }}</span>
+          {% if article.content_type.value == "video" %}
+          <span class="badge video">動画</span>
+          {% endif %}
+          <span class="badge skip-reason">{{ article.content_status if article.content_status else "未処理" }}</span>
+        </div>
+        {% endfor %}
+      </details>
     </section>
     {% endif %}
   </main>

--- a/tests/unit/test_html_builder.py
+++ b/tests/unit/test_html_builder.py
@@ -71,9 +71,7 @@ class TestHtmlBuilder:
             ]
             path = builder.build(articles, last_run_at="2026-03-25 08:00")
             html = path.read_text()
-            assert "総記事数: 2" in html
-            assert "要約済み: 1" in html
-            assert "スキップ: 1" in html
+            assert "2 件" in html
             assert "2026-03-25 08:00" in html
 
     def test_empty(self):
@@ -89,5 +87,6 @@ class TestHtmlBuilder:
             articles = [_make_article(1, drop_candidate=True, drop_reason="価値薄い")]
             path = builder.build(articles)
             html = path.read_text()
-            assert "ドロップ候補" in html
+            assert "drop-candidate" in html
+            assert "DROP" in html
             assert "価値薄い" in html


### PR DESCRIPTION
Closes #29

## Summary

- キーワード検索を削除（不要と判断）
- 主題（topic）をカードから削除（タイトルと重複するため）
- カードフッター（fulltext / untriaged）を削除（現時点では不要）
- 統計表示を簡素化（件数 + 最終実行日時のみ）
- 判定理由を `<details>` で折りたたみ（カードをコンパクトに）
- ドロップ候補に `DROP` バッジ + 破線ボーダー + 薄い表示で視覚的区別
- スキップセクションを折りたたみ式に
- カードホバーエフェクト追加
- スマホ表示の可読性改善（フォントサイズ、行間、タップ領域、折り返し）

## Test plan

- [x] `pytest` 65 テスト全パス
- [x] PC ブラウザで表示確認
- [x] スマホビューで可読性を確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)