### PR TITLE
✨ X（Twitter）記事形式ポストの本文取得に対応 (#34)

### DIFF
--- a/src/content_fetcher.py
+++ b/src/content_fetcher.py
@@ -90,6 +90,54 @@ def should_skip_url(url: str, raindrop_type: str) -> str | None:
     return None
 
 
+def is_x_url(url: str) -> bool:
+    """X（Twitter）の URL かどうかを判定する。"""
+    from urllib.parse import urlparse
+
+    try:
+        host = urlparse(url).hostname or ""
+        return host in ("x.com", "www.x.com", "twitter.com", "www.twitter.com")
+    except Exception:
+        return False
+
+
+def fetch_x_post(url: str) -> dict | None:
+    """vxtwitter API で X ポストの情報を取得する。"""
+    from urllib.parse import urlparse
+
+    try:
+        parsed = urlparse(url)
+        # /user/status/id のパスから user と id を抽出
+        parts = [p for p in parsed.path.split("/") if p]
+        if len(parts) < 3 or parts[1] != "status":
+            return None
+
+        user = parts[0]
+        status_id = parts[2]
+        api_url = f"https://api.vxtwitter.com/{user}/status/{status_id}"
+        resp = httpx.get(api_url, timeout=15)
+        if resp.status_code != 200:
+            logger.warning(f"vxtwitter API エラー: {resp.status_code}")
+            return None
+
+        data = resp.json()
+        result: dict = {
+            "user_name": data.get("user_name", ""),
+            "text": data.get("text", ""),
+        }
+
+        # 記事形式ポストの場合
+        article = data.get("article")
+        if isinstance(article, dict):
+            result["article_title"] = article.get("title", "")
+            result["article_preview"] = article.get("preview_text", "")
+
+        return result
+    except Exception as e:
+        logger.warning(f"X ポスト取得失敗: {e}")
+        return None
+
+
 def _extract_og_description(html: str) -> str:
     """HTML から og:description を正規表現で抽出する。"""
     match = re.search(

--- a/src/main.py
+++ b/src/main.py
@@ -15,7 +15,7 @@ from rich.table import Table
 from src.article_repository import ArticleRepository
 from src.config import Config
 from src.content_extractor import extract_body
-from src.content_fetcher import FetchResult, fetch_url, should_skip_url
+from src.content_fetcher import FetchResult, fetch_url, fetch_x_post, is_x_url, should_skip_url
 from src.html_builder import HtmlBuilder
 from src.logging_util import setup_logger
 from src.models import (
@@ -273,6 +273,61 @@ def _process_article(
 ) -> ProcessedArticle | None:
     """1 記事を処理する。fetch → extract → summarize → save。"""
     rid = raindrop.raindrop_id
+
+    # X（Twitter）ポスト対応
+    if is_x_url(raindrop.url):
+        x_data = fetch_x_post(raindrop.url)
+        fallback_input: dict = {"url": raindrop.url, "domain": raindrop.domain}
+        if raindrop.title:
+            fallback_input["title"] = raindrop.title
+        if x_data:
+            if x_data.get("article_title"):
+                fallback_input["title"] = x_data["article_title"]
+            if x_data.get("article_preview"):
+                fallback_input["excerpt"] = x_data["article_preview"]
+            elif x_data.get("text"):
+                fallback_input["excerpt"] = x_data["text"]
+            if x_data.get("user_name"):
+                fallback_input["author"] = x_data["user_name"]
+
+        now = now_utc()
+        article = ProcessedArticle(
+            raindrop_id=rid,
+            collection_id=raindrop.collection_id,
+            title=fallback_input.get("title", raindrop.title or raindrop.url),
+            url=raindrop.url,
+            domain=raindrop.domain,
+            created_at=raindrop.created_at,
+            fetched_at=now,
+            fetch_status="ok",
+            extract_method="x_api",
+            content_status="fallback",
+            summary_input_type=SummaryInputType.metadata,
+        )
+        state.update_status(rid, ArticleState.fallback_ready)
+
+        result = summarize_fallback(provider, fallback_input)
+        if result:
+            article.topic = result.topic
+            article.summary_3lines = result.summary_3lines
+            article.priority = result.priority
+            article.read_now_reason = result.read_now_reason
+            article.defer_reason = result.defer_reason
+            article.drop_candidate = result.drop_candidate
+            article.drop_reason = result.drop_reason
+            article.keywords = result.keywords
+            article.model_provider = config.llm_provider
+            article.model_name = config.llm_model
+            article.summarized_at = now_utc()
+            state.update_status(rid, ArticleState.summarized)
+            logger.info(f"要約完了 (X): {article.title}")
+        else:
+            article.content_status = "llm_failed"
+            state.update_status(rid, ArticleState.failed, reason="llm_failed")
+            logger.error(f"要約失敗 (X): {article.title}")
+
+        repo.save(article)
+        return article
 
     # 動画スキップ
     skip_reason = should_skip_url(raindrop.url, raindrop.type)


### PR DESCRIPTION
Closes #34

## Summary

- `content_fetcher.py`: X URL 検出 + vxtwitter API でポスト情報を取得
  - `is_x_url()`: x.com / twitter.com の判定
  - `fetch_x_post()`: vxtwitter API で記事形式ポストの title + preview_text を取得
- `main.py`: X URL を検出して専用フローで処理
  - 記事形式ポスト: article の title + preview_text をフォールバック入力に
  - 通常ツイート: ツイート本文をフォールバック入力に

## Test plan

- [x] `pytest` 65 テスト全パス
- [x] `is_x_url`: x.com / twitter.com → True、他 → False
- [x] `fetch_x_post`: 記事形式ポストの title + preview_text を取得確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)