### PR TITLE
✨ 要約テキスト内のインラインコードを適切に表示 (#43)

### DIFF
--- a/docs/styles.css
+++ b/docs/styles.css
@@ -155,6 +155,16 @@ h1 {
   margin-bottom: 3px;
 }
 
+.summary code,
+.reasons code {
+  background: #f1f5f9;
+  padding: 1px 5px;
+  border-radius: 3px;
+  font-size: 0.85em;
+  font-family: "SF Mono", "Fira Code", "Fira Mono", "Roboto Mono", monospace;
+  color: #d6336c;
+}
+
 /* Reasons toggle */
 
 .reasons-toggle {

--- a/src/html_builder.py
+++ b/src/html_builder.py
@@ -1,9 +1,11 @@
 """HTML 出力。Jinja2 テンプレートで docs/index.html を生成する。"""
 
 import logging
+import re
 from pathlib import Path
 
 from jinja2 import Environment, FileSystemLoader
+from markupsafe import Markup, escape
 
 from src.models import ArticleState, Priority, ProcessedArticle
 from src.utils.time import format_display
@@ -11,6 +13,15 @@ from src.utils.time import format_display
 logger = logging.getLogger("raindrop_summarizer")
 
 TEMPLATE_DIR = Path(__file__).parent / "templates"
+
+_INLINE_CODE_RE = re.compile(r"`([^`]+)`")
+
+
+def _render_inline_code(text: str) -> Markup:
+    """テキスト中の `code` をインラインコード表示用の <code> タグに変換する。"""
+    escaped = escape(text)
+    result = _INLINE_CODE_RE.sub(r"<code>\1</code>", str(escaped))
+    return Markup(result)
 
 
 class HtmlBuilder:
@@ -22,6 +33,7 @@ class HtmlBuilder:
             loader=FileSystemLoader(str(TEMPLATE_DIR)),
             autoescape=True,
         )
+        self.env.filters["inline_code"] = _render_inline_code
 
     def build(self, articles: list[ProcessedArticle], last_run_at: str = "") -> Path:
         """記事一覧 HTML を生成する。"""

--- a/src/templates/index.html
+++ b/src/templates/index.html
@@ -40,7 +40,7 @@
         {% if article.summary_3lines %}
         <ul class="summary">
           {% for line in article.summary_3lines %}
-          <li>{{ line }}</li>
+          <li>{{ line | inline_code }}</li>
           {% endfor %}
         </ul>
         {% endif %}
@@ -50,12 +50,12 @@
           <div class="reasons">
             {% if article.read_now_reason %}
             <div class="reason read-now">
-              <span class="reason-label">今読む理由:</span> {{ article.read_now_reason }}
+              <span class="reason-label">今読む理由:</span> {{ article.read_now_reason | inline_code }}
             </div>
             {% endif %}
             {% if article.defer_reason %}
             <div class="reason defer">
-              <span class="reason-label">後回し理由:</span> {{ article.defer_reason }}
+              <span class="reason-label">後回し理由:</span> {{ article.defer_reason | inline_code }}
             </div>
             {% endif %}
             {% if article.drop_candidate %}

--- a/tests/unit/test_html_builder.py
+++ b/tests/unit/test_html_builder.py
@@ -3,7 +3,9 @@
 import tempfile
 from datetime import UTC, datetime
 
-from src.html_builder import HtmlBuilder
+from markupsafe import Markup
+
+from src.html_builder import HtmlBuilder, _render_inline_code
 from src.models import ContentType, Priority, ProcessedArticle, SummaryInputType
 
 
@@ -26,6 +28,27 @@ def _make_article(rid: int, priority: Priority = Priority.medium, **kwargs) -> P
     }
     defaults.update(kwargs)
     return ProcessedArticle(**defaults)
+
+
+class TestRenderInlineCode:
+    def test_backtick_to_code_tag(self):
+        result = _render_inline_code("ツール `cmux` を紹介")
+        assert "<code>cmux</code>" in result
+        assert isinstance(result, Markup)
+
+    def test_multiple_backticks(self):
+        result = _render_inline_code("`Raycast` と `context7 CLI` の比較")
+        assert "<code>Raycast</code>" in result
+        assert "<code>context7 CLI</code>" in result
+
+    def test_no_backticks(self):
+        result = _render_inline_code("普通のテキスト")
+        assert result == "普通のテキスト"
+
+    def test_html_escaped(self):
+        result = _render_inline_code("`<script>` タグ")
+        assert "<script>" not in result
+        assert "<code>&lt;script&gt;</code>" in result
 
 
 class TestHtmlBuilder:
@@ -90,3 +113,11 @@ class TestHtmlBuilder:
             assert "drop-candidate" in html
             assert "DROP" in html
             assert "価値薄い" in html
+
+    def test_inline_code_in_summary(self):
+        with tempfile.TemporaryDirectory() as tmpdir:
+            builder = HtmlBuilder(output_dir=tmpdir)
+            articles = [_make_article(1, summary_3lines=["`cmux` はターミナルツール", "普通の行", "行3"])]
+            path = builder.build(articles)
+            html = path.read_text()
+            assert "<code>cmux</code>" in html


### PR DESCRIPTION
Closes #43

## Summary

- バッククォートで囲まれたインラインコード（`` `cmux` ``、`` `Raycast` `` 等）が記号のまま表示されていた問題を修正
- Jinja2 カスタムフィルター `inline_code` を追加し、`<code>` タグに変換
- CSS でインラインコードに背景色・等幅フォントのスタイルを適用
- 要約（summary_3lines）と判定理由（read_now_reason, defer_reason）に適用

## Test plan

- [x] `pytest` 全テストパス（新規5件含む10件）
- [x] `python -m src build-html` で HTML を再生成し、インラインコードの表示を目視確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)