### PR TITLE
🐛 スマホ表示で件数・最終実行時間を横並びに修正 (#45)

### DIFF
--- a/docs/styles.css
+++ b/docs/styles.css
@@ -310,8 +310,7 @@ footer a:hover {
   }
 
   .stats {
-    flex-direction: column;
-    gap: 4px;
+    gap: 12px;
     font-size: 0.8rem;
   }
 


### PR DESCRIPTION
Closes #45

## Summary

- スマホ表示時に `.stats` が `flex-direction: column` で縦2段になっていたのを修正
- PC表示と同様の横並び表示に統一

## Test plan

- [x] ブラウザのレスポンシブモードでスマホ幅での表示を目視確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)