### PR TITLE
✨ フィルターUI改善: 並び順変更・デフォルトHigh・件数表示 (#51)

### DIFF
--- a/docs/app.js
+++ b/docs/app.js
@@ -2,6 +2,8 @@ document.addEventListener("DOMContentLoaded", () => {
   const buttons = document.querySelectorAll(".filter-btn");
   const cards = document.querySelectorAll(".card");
   const articles = document.querySelector(".articles");
+  const statsCount = document.getElementById("stats-count");
+  const totalCount = cards.length;
 
   // フィルター結果が0件の場合に表示するメッセージ要素
   const emptyMsg = document.createElement("p");
@@ -9,24 +11,33 @@ document.addEventListener("DOMContentLoaded", () => {
   emptyMsg.textContent = "該当する記事はありません。";
   if (articles) articles.appendChild(emptyMsg);
 
+  function applyFilter(filter) {
+    let visibleCount = 0;
+    cards.forEach((card) => {
+      if (filter === "all" || card.dataset.priority === filter) {
+        card.style.display = "";
+        visibleCount++;
+      } else {
+        card.style.display = "none";
+      }
+    });
+    emptyMsg.style.display = visibleCount === 0 ? "block" : "none";
+    if (statsCount) {
+      statsCount.textContent = filter === "all"
+        ? `${totalCount} 件`
+        : `${visibleCount} / ${totalCount} 件`;
+    }
+  }
+
   buttons.forEach((btn) => {
     btn.addEventListener("click", () => {
-      const filter = btn.dataset.filter;
-
       buttons.forEach((b) => b.classList.remove("active"));
       btn.classList.add("active");
-
-      let visibleCount = 0;
-      cards.forEach((card) => {
-        if (filter === "all" || card.dataset.priority === filter) {
-          card.style.display = "";
-          visibleCount++;
-        } else {
-          card.style.display = "none";
-        }
-      });
-
-      emptyMsg.style.display = visibleCount === 0 ? "block" : "none";
+      applyFilter(btn.dataset.filter);
     });
   });
+
+  // 初期表示: active なボタンのフィルターを適用
+  const activeBtn = document.querySelector(".filter-btn.active");
+  if (activeBtn) applyFilter(activeBtn.dataset.filter);
 });

--- a/docs/index.html
+++ b/docs/index.html
@@ -31,14 +31,14 @@
 
   <header>
     <div class="stats">
-      <span>10 件</span>
-      <span>最終実行: 2026-03-25 18:32</span>
+      <span id="stats-count">10 / 10 件</span>
+      <span>最終実行: 2026-03-25 19:41</span>
     </div>
     <div class="filters">
-      <button class="filter-btn active" data-filter="all">すべて</button>
-      <button class="filter-btn" data-filter="high">High</button>
+      <button class="filter-btn active" data-filter="high">High</button>
       <button class="filter-btn" data-filter="medium">Medium</button>
       <button class="filter-btn" data-filter="low">Low</button>
+      <button class="filter-btn" data-filter="all">All</button>
     </div>
   </header>
 

--- a/src/templates/index.html
+++ b/src/templates/index.html
@@ -31,14 +31,14 @@
 
   <header>
     <div class="stats">
-      <span>{{ total }} 件</span>
+      <span id="stats-count">{{ total }} / {{ total }} 件</span>
       {% if last_run_at %}<span>最終実行: {{ last_run_at }}</span>{% endif %}
     </div>
     <div class="filters">
-      <button class="filter-btn active" data-filter="all">すべて</button>
-      <button class="filter-btn" data-filter="high">High</button>
+      <button class="filter-btn active" data-filter="high">High</button>
       <button class="filter-btn" data-filter="medium">Medium</button>
       <button class="filter-btn" data-filter="low">Low</button>
+      <button class="filter-btn" data-filter="all">All</button>
     </div>
   </header>
 


### PR DESCRIPTION
Closes #51

## Summary

- フィルターボタンの並び順を High → Medium → Low → All に変更
- デフォルト表示を High フィルターに変更（ページ読み込み時に自動適用）
- 「すべて」を「All」にリネームし右端に配置
- フィルター切り替え時に「フィルター件数 / 全件数」を表示（All 選択時は全件数のみ）

## Test plan

- [x] 初期表示で High フィルターが適用されていることを確認
- [x] 各フィルター切り替え時に件数表示が変わることを確認
- [x] All 選択時は全件数のみ表示されることを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)