### PR TITLE
📚 README を英語ベースにリライト・日本語版切り替え・バッジ追加 (#53)

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,94 +1,103 @@
 # Tsuyu-mi
+[日本語](README_ja.md)
 
-Raindrop.io の特定コレクションを定期取得し、保存記事の本文を抽出して AI で短く要約し、優先度付きの HTML ダッシュボードとして出力するツールです。
+[![Python](https://img.shields.io/badge/Python-3.11+-3776AB.svg?logo=python&logoColor=white)](https://www.python.org/)
+[![License](https://img.shields.io/badge/license-MIT-green.svg)](LICENSE)
+[![GitHub Actions](https://img.shields.io/badge/CI%2FCD-GitHub_Actions-2088FF.svg?logo=githubactions&logoColor=white)](https://github.com/unsolublesugar/tsuyu-mi/actions)<br>
+![Raindrop.io](https://img.shields.io/badge/Raindrop.io-0B7ED0?logo=data:image/svg+xml;base64,PHN2ZyB4bWxucz0iaHR0cDovL3d3dy53My5vcmcvMjAwMC9zdmciIHZpZXdCb3g9IjAgMCAyNCAyNCIgZmlsbD0id2hpdGUiPjxjaXJjbGUgY3g9IjEyIiBjeT0iMTIiIHI9IjEwIi8+PC9zdmc+)
+![Jinja2](https://img.shields.io/badge/Jinja2-B41717?logo=jinja&logoColor=white)
+![Pydantic](https://img.shields.io/badge/Pydantic-E92063?logo=pydantic&logoColor=white)
 
 ![Tsuyu-mi](assets/images/screenshot.png)
 
-## 目的
+Periodically fetches articles from a Raindrop.io collection, extracts their content, summarizes them with AI, and outputs a priority-ranked HTML dashboard.
 
-Raindrop に溜めた「あとで読む」記事を、全文を読む前に一次判定できる状態にします。
+## Purpose
 
-- 今読むべきか
-- 後回しでよいか
-- 読まずに捨ててよいか
+Triage your "read later" articles saved in Raindrop — before reading the full text.
 
-## セットアップ
+- **Read now** — timely or high-value
+- **Defer** — interesting but not urgent
+- **Drop** — safe to discard
 
-### 1. リポジトリをクローン
+## Setup
+
+### 1. Clone the repository
 
 ```bash
 git clone https://github.com/unsolublesugar/tsuyu-mi.git
 cd tsuyu-mi
 ```
 
-### 2. Python 環境を用意
+### 2. Prepare the Python environment
 
-Python 3.11 以上が必要です。[uv](https://docs.astral.sh/uv/) を使うと Python ごとインストールできます。
+> [!NOTE]
+> Python 3.11 or later is required. [uv](https://docs.astral.sh/uv/) can install Python itself alongside dependencies.
 
 ```bash
-# uv を使う場合（推奨）
+# Using uv (recommended)
 uv venv --python 3.11
 source .venv/bin/activate
 uv pip install -e ".[dev]"
 
-# pip を使う場合
+# Using pip
 python -m venv .venv
 source .venv/bin/activate
 pip install -e ".[dev]"
 ```
 
-### 3. API キーの取得
+### 3. Obtain API keys
 
-このツールの実行には **Raindrop.io API トークン** と **LLM API キー** の 2 つが必要です。
+This tool requires a **Raindrop.io API token** and an **LLM API key**.
 
-#### Raindrop.io テストトークン
+#### Raindrop.io test token
 
-1. [Raindrop.io Integrations](https://app.raindrop.io/settings/integrations) にアクセス
-2. 「For Developers」セクションの **Create new app** をクリック
-3. アプリ名を入力（例: `RaindropSummarizer`）して作成
-4. 作成したアプリをクリック → **Create test token** をクリック
-5. 表示されたトークンをコピー
+1. Go to [Raindrop.io Integrations](https://app.raindrop.io/settings/integrations)
+2. Click **Create new app** under "For Developers"
+3. Enter an app name (e.g. `RaindropSummarizer`) and create it
+4. Click the app → **Create test token**
+5. Copy the displayed token
 
-#### コレクション ID の確認
+#### Collection ID
 
-1. [Raindrop.io](https://app.raindrop.io) にアクセス
-2. 対象のコレクション（「あとで読む」等）を開く
-3. URL を確認: `https://app.raindrop.io/my/{collection_id}` — この数値部分がコレクション ID
+1. Open [Raindrop.io](https://app.raindrop.io)
+2. Navigate to the target collection (e.g. "Unsorted")
+3. Check the URL: `https://app.raindrop.io/my/{collection_id}` — the numeric part is the collection ID
 
-#### LLM API キー
+#### LLM API key
 
-以下のいずれか 1 つのプロバイダーの API キーを取得します。
+Obtain an API key from one of the following providers:
 
-**Google Gemini（推奨・無料枠あり）**
+**Google Gemini (recommended — has a free tier)**
 
-1. [Google AI Studio](https://aistudio.google.com/apikey) にアクセス
-2. **Create API Key** → **Create API key in new project** を選択
-3. API キーが発行される
-4. 推奨モデル: `gemini-2.5-flash`
+1. Go to [Google AI Studio](https://aistudio.google.com/apikey)
+2. **Create API Key** → **Create API key in new project**
+3. Recommended model: `gemini-2.5-flash`
 
-> Google Cloud の請求先アカウントの紐づけと [Gemini API の有効化](https://console.cloud.google.com/apis/library/generativelanguage.googleapis.com) が必要な場合があります。
+> [!TIP]
+> You may need to link a Google Cloud billing account and [enable the Gemini API](https://console.cloud.google.com/apis/library/generativelanguage.googleapis.com).
 
 **OpenAI**
 
-1. [OpenAI API Keys](https://platform.openai.com/api-keys) にアクセス
-2. **Create new secret key** でキーを生成
-3. 推奨モデル: `gpt-4.1-mini`
+1. Go to [OpenAI API Keys](https://platform.openai.com/api-keys)
+2. **Create new secret key**
+3. Recommended model: `gpt-4.1-mini`
 
 **Anthropic**
 
-1. [Anthropic Console](https://console.anthropic.com/settings/keys) にアクセス
-2. **Create Key** でキーを生成
-3. 推奨モデル: `claude-haiku-4-5-20251001`
+1. Go to [Anthropic Console](https://console.anthropic.com/settings/keys)
+2. **Create Key**
+3. Recommended model: `claude-haiku-4-5-20251001`
 
-### 4. 環境変数の設定
+### 4. Configure environment variables
 
-#### ローカル実行の場合
+#### Local execution
 
 ```bash
 cp .env.example .env
 ```
 
-`.env` を開いて取得したキーを設定します:
+Edit `.env` with your keys:
 
 ```env
 RAINDROP_TOKEN=your-raindrop-token
@@ -98,110 +107,110 @@ LLM_API_KEY=your-llm-api-key
 LLM_MODEL=gemini-2.5-flash
 ```
 
-> `.env` はリポジトリにコミットしないでください。
+> [!WARNING]
+> Never commit `.env` to the repository — it contains secrets.
 
-#### GitHub Actions の場合
+#### GitHub Actions
 
-リポジトリの Settings → Secrets and variables → Actions → Repository secrets に以下を設定:
+Add the following to your repository: Settings → Secrets and variables → Actions → Repository secrets.
 
-| Secret 名 | 値 |
+| Secret name | Value |
 |---|---|
-| `RAINDROP_TOKEN` | Raindrop.io API テストトークン |
-| `RAINDROP_COLLECTION_ID` | 対象コレクション ID |
+| `RAINDROP_TOKEN` | Raindrop.io API test token |
+| `RAINDROP_COLLECTION_ID` | Target collection ID |
 | `LLM_PROVIDER` | `gemini` / `openai` / `anthropic` |
-| `LLM_API_KEY` | LLM の API キー |
-| `LLM_MODEL` | モデル名（例: `gemini-2.5-flash`） |
+| `LLM_API_KEY` | LLM API key |
+| `LLM_MODEL` | Model name (e.g. `gemini-2.5-flash`) |
 
-### 5. 動作確認
+### 5. Verify
 
 ```bash
-# まず Raindrop API の接続だけ確認（LLM 不要）
+# Test Raindrop API connectivity only (no LLM required)
 python -m src fetch-only
 
-# 少数で要約を試す
+# Summarize a small batch
 MAX_SUMMARIZE_PER_RUN=3 python -m src run
 
-# 問題なければフル実行
+# Full run
 python -m src run
 ```
 
-## 使い方
+## Usage
 
 ```bash
-# フルパイプライン実行（取得 → 抽出 → 要約 → HTML 生成）
+# Full pipeline (fetch → extract → summarize → generate HTML)
 python -m src run
 
-# 対象記事を確認だけ（処理はしない）
+# Dry run — preview target articles without processing
 python -m src run --dry-run
 
-# 詳細ログ付き実行
+# Verbose logging
 python -m src run --verbose
 
-# Raindrop 取得のみ
+# Fetch from Raindrop only
 python -m src fetch-only
 
-# HTML 再生成
+# Regenerate HTML
 python -m src build-html
 
-# 特定記事の再処理
+# Reprocess a specific article
 python -m src reprocess --id 123456789
 
-# 失敗記事の一括再試行
+# Retry all failed articles
 python -m src reprocess-failed
 ```
 
-## 出力
+## Output
 
-`docs/index.html` に記事一覧が生成されます。ブラウザで開いて確認できます。
+An article dashboard is generated at `docs/index.html`. Open it in a browser to review.
 
-- 優先度ごとに色分け（HIGH=赤 / MEDIUM=黄 / LOW=灰）
-- フィルタボタンで優先度別に絞り込み可能
-- 各記事に 3 行要約・今読む理由・後回し理由・キーワードを表示
+- Color-coded by priority (HIGH = red / MEDIUM = yellow / LOW = gray)
+- Filter buttons to narrow by priority
+- Each article shows a 3-line summary, read-now reason, defer reason, and keywords
 
-## 設定
+## Configuration
 
-| 環境変数 | 説明 | デフォルト |
+| Environment variable | Description | Default |
 |---|---|---|
-| `RAINDROP_TOKEN` | Raindrop.io API テストトークン | （必須） |
-| `RAINDROP_COLLECTION_ID` | 対象コレクション ID | （必須） |
+| `RAINDROP_TOKEN` | Raindrop.io API test token | (required) |
+| `RAINDROP_COLLECTION_ID` | Target collection ID | (required) |
 | `LLM_PROVIDER` | `openai` / `gemini` / `anthropic` | `openai` |
-| `LLM_API_KEY` | LLM の API キー | （必須） |
-| `LLM_MODEL` | 使用するモデル名 | （必須） |
-| `MAX_SUMMARIZE_PER_RUN` | 1 回の要約件数上限 | `10` |
-| `REQUEST_TIMEOUT_SECONDS` | HTTP リクエストタイムアウト | `20` |
-| `USER_AGENT` | HTTP リクエストの User-Agent | `Tsuyu-mi/0.1` |
-| `OUTPUT_DIR` | HTML 出力先ディレクトリ | `docs` |
-| `DATA_DIR` | データ保存ディレクトリ | `data` |
-| `STATE_DIR` | 状態管理ディレクトリ | `state` |
-| `LOG_LEVEL` | ログレベル | `INFO` |
+| `LLM_API_KEY` | LLM API key | (required) |
+| `LLM_MODEL` | Model name | (required) |
+| `MAX_SUMMARIZE_PER_RUN` | Max articles to summarize per run | `10` |
+| `REQUEST_TIMEOUT_SECONDS` | HTTP request timeout (seconds) | `20` |
+| `USER_AGENT` | HTTP User-Agent header | `Tsuyu-mi/0.1` |
+| `OUTPUT_DIR` | HTML output directory | `docs` |
+| `DATA_DIR` | Data storage directory | `data` |
+| `STATE_DIR` | State management directory | `state` |
+| `LOG_LEVEL` | Log level | `INFO` |
 
-## GitHub Actions による自動運用
+## Automated operation with GitHub Actions
 
-### 1. GitHub Secrets の設定
+### 1. Set up GitHub Secrets
 
-セットアップの「4. 環境変数の設定 → GitHub Actions の場合」を参照してください。
+See "4. Configure environment variables → GitHub Actions" above.
 
-### 2. GitHub Pages の有効化
+### 2. Enable GitHub Pages
 
-Settings → Pages → Source を **Deploy from a branch** に設定:
-- Branch: `main`
-- Folder: `/docs`
+Settings → Pages → Source: **GitHub Actions**
 
-> プライベートリポジトリで GitHub Pages を使うには **GitHub Pro** 以上が必要です。
+> [!IMPORTANT]
+> Private repositories require **GitHub Pro** or higher to use GitHub Pages.
 
-### 3. 実行スケジュール
+### 3. Execution schedule
 
-- **自動実行**: 3 日おき JST 7:00（UTC 22:00）
-- **手動実行**: Actions タブから「Run workflow」で即時実行可能
+- **Automatic**: Every 3 days at JST 7:00 (UTC 22:00)
+- **Manual**: Run on demand from the Actions tab via "Run workflow"
 
-変更があった場合のみ自動コミット・プッシュされます。
+Changes are auto-committed and pushed only when new content is generated.
 
-## テスト
+## Testing
 
 ```bash
 pytest
 ```
 
-## ライセンス
+## License
 
-MIT
+[MIT](LICENSE)

--- a/README_ja.md
+++ b/README_ja.md
@@ -1,0 +1,216 @@
+# Tsuyu-mi
+[English](README.md)
+
+[![Python](https://img.shields.io/badge/Python-3.11+-3776AB.svg?logo=python&logoColor=white)](https://www.python.org/)
+[![License](https://img.shields.io/badge/license-MIT-green.svg)](LICENSE)
+[![GitHub Actions](https://img.shields.io/badge/CI%2FCD-GitHub_Actions-2088FF.svg?logo=githubactions&logoColor=white)](https://github.com/unsolublesugar/tsuyu-mi/actions)<br>
+![Raindrop.io](https://img.shields.io/badge/Raindrop.io-0B7ED0?logo=data:image/svg+xml;base64,PHN2ZyB4bWxucz0iaHR0cDovL3d3dy53My5vcmcvMjAwMC9zdmciIHZpZXdCb3g9IjAgMCAyNCAyNCIgZmlsbD0id2hpdGUiPjxjaXJjbGUgY3g9IjEyIiBjeT0iMTIiIHI9IjEwIi8+PC9zdmc+)
+![Jinja2](https://img.shields.io/badge/Jinja2-B41717?logo=jinja&logoColor=white)
+![Pydantic](https://img.shields.io/badge/Pydantic-E92063?logo=pydantic&logoColor=white)
+
+![Tsuyu-mi](assets/images/screenshot.png)
+
+Raindrop.io の特定コレクションを定期取得し、保存記事の本文を抽出して AI で短く要約し、優先度付きの HTML ダッシュボードとして出力するツールです。
+
+## 目的
+
+Raindrop に溜めた「あとで読む」記事を、全文を読む前に一次判定できる状態にします。
+
+- **今読むべきか** — タイムリーで価値が高い
+- **後回しでよいか** — 興味はあるが急ぎではない
+- **読まずに捨ててよいか** — 破棄しても問題ない
+
+## セットアップ
+
+### 1. リポジトリをクローン
+
+```bash
+git clone https://github.com/unsolublesugar/tsuyu-mi.git
+cd tsuyu-mi
+```
+
+### 2. Python 環境を用意
+
+> [!NOTE]
+> Python 3.11 以上が必要です。[uv](https://docs.astral.sh/uv/) を使うと Python ごとインストールできます。
+
+```bash
+# uv を使う場合（推奨）
+uv venv --python 3.11
+source .venv/bin/activate
+uv pip install -e ".[dev]"
+
+# pip を使う場合
+python -m venv .venv
+source .venv/bin/activate
+pip install -e ".[dev]"
+```
+
+### 3. API キーの取得
+
+このツールの実行には **Raindrop.io API トークン** と **LLM API キー** の 2 つが必要です。
+
+#### Raindrop.io テストトークン
+
+1. [Raindrop.io Integrations](https://app.raindrop.io/settings/integrations) にアクセス
+2. 「For Developers」セクションの **Create new app** をクリック
+3. アプリ名を入力（例: `RaindropSummarizer`）して作成
+4. 作成したアプリをクリック → **Create test token** をクリック
+5. 表示されたトークンをコピー
+
+#### コレクション ID の確認
+
+1. [Raindrop.io](https://app.raindrop.io) にアクセス
+2. 対象のコレクション（「あとで読む」等）を開く
+3. URL を確認: `https://app.raindrop.io/my/{collection_id}` — この数値部分がコレクション ID
+
+#### LLM API キー
+
+以下のいずれか 1 つのプロバイダーの API キーを取得します。
+
+**Google Gemini（推奨・無料枠あり）**
+
+1. [Google AI Studio](https://aistudio.google.com/apikey) にアクセス
+2. **Create API Key** → **Create API key in new project** を選択
+3. 推奨モデル: `gemini-2.5-flash`
+
+> [!TIP]
+> Google Cloud の請求先アカウントの紐づけと [Gemini API の有効化](https://console.cloud.google.com/apis/library/generativelanguage.googleapis.com) が必要な場合があります。
+
+**OpenAI**
+
+1. [OpenAI API Keys](https://platform.openai.com/api-keys) にアクセス
+2. **Create new secret key** でキーを生成
+3. 推奨モデル: `gpt-4.1-mini`
+
+**Anthropic**
+
+1. [Anthropic Console](https://console.anthropic.com/settings/keys) にアクセス
+2. **Create Key** でキーを生成
+3. 推奨モデル: `claude-haiku-4-5-20251001`
+
+### 4. 環境変数の設定
+
+#### ローカル実行の場合
+
+```bash
+cp .env.example .env
+```
+
+`.env` を開いて取得したキーを設定します:
+
+```env
+RAINDROP_TOKEN=your-raindrop-token
+RAINDROP_COLLECTION_ID=your-collection-id
+LLM_PROVIDER=gemini
+LLM_API_KEY=your-llm-api-key
+LLM_MODEL=gemini-2.5-flash
+```
+
+> [!WARNING]
+> `.env` はリポジトリにコミットしないでください。シークレット情報が含まれます。
+
+#### GitHub Actions の場合
+
+リポジトリの Settings → Secrets and variables → Actions → Repository secrets に以下を設定:
+
+| Secret 名 | 値 |
+|---|---|
+| `RAINDROP_TOKEN` | Raindrop.io API テストトークン |
+| `RAINDROP_COLLECTION_ID` | 対象コレクション ID |
+| `LLM_PROVIDER` | `gemini` / `openai` / `anthropic` |
+| `LLM_API_KEY` | LLM の API キー |
+| `LLM_MODEL` | モデル名（例: `gemini-2.5-flash`） |
+
+### 5. 動作確認
+
+```bash
+# まず Raindrop API の接続だけ確認（LLM 不要）
+python -m src fetch-only
+
+# 少数で要約を試す
+MAX_SUMMARIZE_PER_RUN=3 python -m src run
+
+# 問題なければフル実行
+python -m src run
+```
+
+## 使い方
+
+```bash
+# フルパイプライン実行（取得 → 抽出 → 要約 → HTML 生成）
+python -m src run
+
+# 対象記事を確認だけ（処理はしない）
+python -m src run --dry-run
+
+# 詳細ログ付き実行
+python -m src run --verbose
+
+# Raindrop 取得のみ
+python -m src fetch-only
+
+# HTML 再生成
+python -m src build-html
+
+# 特定記事の再処理
+python -m src reprocess --id 123456789
+
+# 失敗記事の一括再試行
+python -m src reprocess-failed
+```
+
+## 出力
+
+`docs/index.html` に記事一覧が生成されます。ブラウザで開いて確認できます。
+
+- 優先度ごとに色分け（HIGH=赤 / MEDIUM=黄 / LOW=灰）
+- フィルタボタンで優先度別に絞り込み可能
+- 各記事に 3 行要約・今読む理由・後回し理由・キーワードを表示
+
+## 設定
+
+| 環境変数 | 説明 | デフォルト |
+|---|---|---|
+| `RAINDROP_TOKEN` | Raindrop.io API テストトークン | （必須） |
+| `RAINDROP_COLLECTION_ID` | 対象コレクション ID | （必須） |
+| `LLM_PROVIDER` | `openai` / `gemini` / `anthropic` | `openai` |
+| `LLM_API_KEY` | LLM の API キー | （必須） |
+| `LLM_MODEL` | 使用するモデル名 | （必須） |
+| `MAX_SUMMARIZE_PER_RUN` | 1 回の要約件数上限 | `10` |
+| `REQUEST_TIMEOUT_SECONDS` | HTTP リクエストタイムアウト | `20` |
+| `USER_AGENT` | HTTP リクエストの User-Agent | `Tsuyu-mi/0.1` |
+| `OUTPUT_DIR` | HTML 出力先ディレクトリ | `docs` |
+| `DATA_DIR` | データ保存ディレクトリ | `data` |
+| `STATE_DIR` | 状態管理ディレクトリ | `state` |
+| `LOG_LEVEL` | ログレベル | `INFO` |
+
+## GitHub Actions による自動運用
+
+### 1. GitHub Secrets の設定
+
+セットアップの「4. 環境変数の設定 → GitHub Actions の場合」を参照してください。
+
+### 2. GitHub Pages の有効化
+
+Settings → Pages → Source を **GitHub Actions** に設定
+
+> [!IMPORTANT]
+> プライベートリポジトリで GitHub Pages を使うには **GitHub Pro** 以上が必要です。
+
+### 3. 実行スケジュール
+
+- **自動実行**: 3 日おき JST 7:00（UTC 22:00）
+- **手動実行**: Actions タブから「Run workflow」で即時実行可能
+
+変更があった場合のみ自動コミット・プッシュされます。
+
+## テスト
+
+```bash
+pytest
+```
+
+## ライセンス
+
+[MIT](LICENSE)


### PR DESCRIPTION
Closes #53

## Summary

- README.md を英語にリライトし、冒頭に日本語版への切り替えリンクを追加
- README_ja.md を新規作成し、冒頭に英語版への切り替えリンクを追加
- 使用技術バッジ（Python, Raindrop.io, Jinja2, Pydantic）・ライセンスバッジ・GitHub Actions バッジを追加
- GitHub Markdown アラート（NOTE, TIP, WARNING, IMPORTANT）を適切な箇所に適用
- GitHub Pages の Source 表記を実態に合わせて「GitHub Actions」に修正

## Test plan

- [ ] GitHub 上で README.md の表示を確認（バッジ・アラート・言語切り替えリンク）
- [ ] GitHub 上で README_ja.md の表示を確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)