### PR TITLE
🔒 セキュリティ改善: Actions sha ピン留め・依存強化・エラー処理改善 (#55)

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -20,10 +20,10 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5  # v4
 
       - name: Setup Python
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065  # v5
         with:
           python-version: '3.11'
 
@@ -47,7 +47,7 @@ jobs:
           git diff --cached --quiet && echo "No changes to commit" || (git commit -m "🤖 記事を要約・HTML を更新 $(date -u +'%Y-%m-%d')" && git push)
 
       - name: Upload Pages artifact
-        uses: actions/upload-pages-artifact@v3
+        uses: actions/upload-pages-artifact@56afc609e74202658d3ffba0e8f6dda462b719fa  # v3
         with:
           path: docs/
 
@@ -60,4 +60,4 @@ jobs:
     steps:
       - name: Deploy to GitHub Pages
         id: deployment
-        uses: actions/deploy-pages@v4
+        uses: actions/deploy-pages@d6db90164ac5ed86f2b6aed7e0febac5b3c0c03e  # v4

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,18 +4,19 @@ version = "0.1.0"
 description = "Raindrop.io コレクションの記事を取得・要約し HTML 一覧として出力するバッチツール — Tsuyu-mi"
 requires-python = ">=3.11"
 dependencies = [
-    "httpx>=0.27",
-    "pydantic>=2.0",
-    "pydantic-settings>=2.0",
+    "httpx>=0.27.2",
+    "pydantic>=2.10",
+    "pydantic-settings>=2.7",
     "python-dotenv>=1.0",
-    "trafilatura>=1.8",
-    "readability-lxml>=0.8",
-    "jinja2>=3.1",
-    "rich>=13.0",
-    "click>=8.1",
-    "openai>=1.0",
-    "google-genai>=1.0",
-    "anthropic>=0.30",
+    "trafilatura>=2.0",
+    "readability-lxml>=0.8.1",
+    "jinja2>=3.1.5",
+    "markupsafe>=2.1.5",
+    "rich>=13.9",
+    "click>=8.1.8",
+    "openai>=1.60",
+    "google-genai>=1.5",
+    "anthropic>=0.44",
 ]
 
 [project.optional-dependencies]
@@ -24,6 +25,7 @@ dev = [
     "pytest-cov>=5.0",
     "respx>=0.21",
     "ruff>=0.4",
+    "pip-audit>=2.7",
 ]
 
 [build-system]

--- a/src/content_fetcher.py
+++ b/src/content_fetcher.py
@@ -34,6 +34,7 @@ def fetch_url(url: str, config: Config) -> FetchResult:
             timeout=config.request_timeout_seconds,
             headers={"User-Agent": config.user_agent},
             follow_redirects=True,
+            max_redirects=10,
         ) as client:
             response = client.get(url)
             response.raise_for_status()

--- a/src/html_builder.py
+++ b/src/html_builder.py
@@ -7,7 +7,7 @@ from pathlib import Path
 from jinja2 import Environment, FileSystemLoader
 from markupsafe import Markup, escape
 
-from src.models import ArticleState, Priority, ProcessedArticle
+from src.models import Priority, ProcessedArticle
 from src.utils.time import format_display
 
 logger = logging.getLogger("raindrop_summarizer")

--- a/src/raindrop_client.py
+++ b/src/raindrop_client.py
@@ -53,7 +53,13 @@ class RaindropClient:
                 break
 
             response.raise_for_status()
-            data = response.json()
+
+            try:
+                data = response.json()
+            except ValueError:
+                logger.error("Raindrop API: JSON パースエラー")
+                break
+
             items = data.get("items", [])
 
             if not items:
@@ -126,7 +132,13 @@ class RaindropClient:
                 break
 
             response.raise_for_status()
-            data = response.json()
+
+            try:
+                data = response.json()
+            except ValueError:
+                logger.error("Raindrop API: JSON パースエラー")
+                break
+
             items = data.get("items", [])
 
             if not items:


### PR DESCRIPTION
Closes #55

## Summary

- **P0**: GitHub Actions のアクションを sha でピン留め（タグ上書き攻撃対策）
- **P1**: 依存パッケージのバージョン下限をセキュリティパッチ適用版に引き上げ
- **P1**: `pip-audit` を dev 依存に追加（セキュリティスキャン用）
- **P1**: Raindrop API の JSON パースエラーを try-except で適切にハンドリング
- **P2**: HTTP リダイレクト上限を `max_redirects=10` で明示設定
- `html_builder.py` の未使用 import (`ArticleState`) を削除

## Test plan

- [x] `pytest` 全70テストパス
- [x] GitHub Actions ワークフローが正常に実行されること

🤖 Generated with [Claude Code](https://claude.com/claude-code)