### PR TITLE
🐛 新規記事なし時にも最終実行時間をHTMLに反映 (#57)

### DIFF
--- a/src/main.py
+++ b/src/main.py
@@ -81,6 +81,7 @@ def run(dry_run: bool, verbose: bool) -> None:
         console.print("[green]新規記事なし。終了します。[/green]")
         state.mark_run_completed()
         state.save()
+        _build_html(config, repo, state)
         return
 
     # 3. 各記事を処理


### PR DESCRIPTION
Closes #57

## Summary

- 新規記事がない場合でも `_build_html()` を実行し、`last_run_at` を HTML に反映する
- 以前は `state.save()` 後に `return` しており HTML 再生成がスキップされていた

## Test plan

- [x] `pytest` 全70テストパス
- [x] Actions で新規記事なし時に最終実行時間が更新されることを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)