### PR TITLE
🐛 未要約の記事が処理対象から漏れる問題を修正 (#61)

### DIFF
--- a/src/state_store.py
+++ b/src/state_store.py
@@ -40,16 +40,15 @@ class StateStore:
     def get_new_articles(
         self, raindrops: list[RaindropItem], max_count: int = 30
     ) -> list[RaindropItem]:
-        """未処理の新規記事を抽出する。created_at の新しい順、上限 max_count 件。"""
-        existing_ids = set(self.index.items.keys())
-        new_items = [r for r in raindrops if str(r.raindrop_id) not in existing_ids]
-        new_items.sort(key=lambda r: r.created_at, reverse=True)
+        """未要約の記事を抽出する。created_at の新しい順、上限 max_count 件。"""
+        summarized_ids = {
+            rid for rid, entry in self.index.items.items()
+            if entry.status == ArticleState.summarized
+        }
+        unsummarized = [r for r in raindrops if str(r.raindrop_id) not in summarized_ids]
+        unsummarized.sort(key=lambda r: r.created_at, reverse=True)
 
-        # 上限を超えた分は pending として登録
-        for item in new_items[max_count:]:
-            self._set_entry(str(item.raindrop_id), ArticleState.pending)
-
-        return new_items[:max_count]
+        return unsummarized[:max_count]
 
     def get_failed_ids(self) -> list[str]:
         """status が failed のエントリの ID リストを返す。"""

--- a/tests/unit/test_state_store.py
+++ b/tests/unit/test_state_store.py
@@ -31,15 +31,16 @@ class TestStateStore:
             assert new[0].raindrop_id == 2  # newest first
             assert new[1].raindrop_id == 3
 
-    def test_overflow_becomes_pending(self):
+    def test_overflow_not_registered(self):
+        """上限超過分は state に登録されない（次回再検出される）。"""
         with tempfile.TemporaryDirectory() as tmpdir:
             store = StateStore(state_dir=tmpdir)
             raindrops = [_make_raindrop(1, 5), _make_raindrop(2, 0), _make_raindrop(3, 3)]
             store.get_new_articles(raindrops, max_count=2)
-            assert "1" in store.index.items
-            assert store.index.items["1"].status == ArticleState.pending
+            assert "1" not in store.index.items
 
-    def test_skips_existing(self):
+    def test_skips_summarized(self):
+        """要約済みの記事はスキップされる。"""
         with tempfile.TemporaryDirectory() as tmpdir:
             store = StateStore(state_dir=tmpdir)
             store.update_status(1, ArticleState.summarized)
@@ -47,6 +48,24 @@ class TestStateStore:
             new = store.get_new_articles(raindrops, max_count=10)
             assert len(new) == 1
             assert new[0].raindrop_id == 2
+
+    def test_pending_retried(self):
+        """pending 状態の記事は再検出される。"""
+        with tempfile.TemporaryDirectory() as tmpdir:
+            store = StateStore(state_dir=tmpdir)
+            store.update_status(1, ArticleState.pending)
+            raindrops = [_make_raindrop(1), _make_raindrop(2)]
+            new = store.get_new_articles(raindrops, max_count=10)
+            assert len(new) == 2
+
+    def test_failed_retried(self):
+        """failed 状態の記事は再検出される。"""
+        with tempfile.TemporaryDirectory() as tmpdir:
+            store = StateStore(state_dir=tmpdir)
+            store.update_status(1, ArticleState.failed)
+            raindrops = [_make_raindrop(1), _make_raindrop(2)]
+            new = store.get_new_articles(raindrops, max_count=10)
+            assert len(new) == 2
 
     def test_update_status(self):
         with tempfile.TemporaryDirectory() as tmpdir:


### PR DESCRIPTION
Closes #61

## Summary

- `get_new_articles` で `summarized` のみスキップし、`pending` / `failed` は再検出されるよう変更
- 上限超過分の `pending` 登録を廃止（次回実行時に自然に再検出される）
- テスト更新: `pending` / `failed` 記事の再検出テストを追加

## Test plan

- [x] `pytest` 全72テストパス
- [x] Actions で未要約記事が正しく要約されることを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)