### PR TITLE
✨ フッター: 運営者リンク先をポートフォリオサイトに変更 (#65)

### DIFF
--- a/docs/index.html
+++ b/docs/index.html
@@ -934,7 +934,7 @@
   </main>
 
   <footer>
-    <p>🚀 運営者: <a href="https://x.com/unsoluble_sugar" target="_blank" rel="noopener">@unsoluble_sugar</a> | 📁 <a href="https://github.com/unsolublesugar/tsuyu-mi" target="_blank" rel="noopener">GitHub Repository</a></p>
+    <p>🚀 <a href="https://unsolublesugar.github.io/portfolio/" target="_blank" rel="noopener">@unsoluble_sugar</a> | 📁 <a href="https://github.com/unsolublesugar/tsuyu-mi" target="_blank" rel="noopener">GitHub Repository</a></p>
   </footer>
 
   <script src="app.js"></script>

--- a/src/templates/index.html
+++ b/src/templates/index.html
@@ -122,7 +122,7 @@
   </main>
 
   <footer>
-    <p>🚀 運営者: <a href="https://x.com/unsoluble_sugar" target="_blank" rel="noopener">@unsoluble_sugar</a> | 📁 <a href="https://github.com/unsolublesugar/tsuyu-mi" target="_blank" rel="noopener">GitHub Repository</a></p>
+    <p>🚀 <a href="https://unsolublesugar.github.io/portfolio/" target="_blank" rel="noopener">@unsoluble_sugar</a> | 📁 <a href="https://github.com/unsolublesugar/tsuyu-mi" target="_blank" rel="noopener">GitHub Repository</a></p>
   </footer>
 
   <script src="app.js"></script>


### PR DESCRIPTION
Closes #65

## 変更内容

- フッターの `🚀 運営者: ` プレフィックスを削除
- `@unsoluble_sugar` のリンク先を X アカウントから作者ポートフォリオサイト (<https://unsolublesugar.github.io/portfolio/>) に変更
- 対象ファイル:
  - `src/templates/index.html`（メインテンプレート）
  - `docs/index.html`（現行の出力ファイル）

## 変更理由

最近公開した作者ポートフォリオサイトへ導線を流すため、X アカウントリンクから差し替える。
（[daily-tech-news#119](https://github.com/unsolublesugar/daily-tech-news/pull/119) と同等の対応）

## 対象外

- `docs/archives/` 配下の過去分 HTML は置換しない（過去の公開時点のメタ情報として保持）

## テスト方法

- [x] ローカルで `docs/index.html` をブラウザ表示し、フッター表記が意図どおり（「運営者:」非表示・ポートフォリオへ遷移）であることを確認
- [x] PR マージ後、GitHub Pages 反映後にフッターリンクがポートフォリオサイトに遷移することを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)