### PR TITLE
🔧 CI: GitHub Actions を Node.js 24 対応版に更新 (#69)

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -20,10 +20,10 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5  # v4
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
 
       - name: Setup Python
-        uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065  # v5
+        uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405  # v6.2.0
         with:
           python-version: '3.11'
 
@@ -47,7 +47,7 @@ jobs:
           git diff --cached --quiet && echo "No changes to commit" || (git commit -m "🤖 記事を要約・HTML を更新 $(date -u +'%Y-%m-%d')" && git push)
 
       - name: Upload Pages artifact
-        uses: actions/upload-pages-artifact@56afc609e74202658d3ffba0e8f6dda462b719fa  # v3
+        uses: actions/upload-pages-artifact@fc324d3547104276b827a68afc52ff2a11cc49c9  # v5.0.0
         with:
           path: docs/
 
@@ -60,4 +60,4 @@ jobs:
     steps:
       - name: Deploy to GitHub Pages
         id: deployment
-        uses: actions/deploy-pages@d6db90164ac5ed86f2b6aed7e0febac5b3c0c03e  # v4
+        uses: actions/deploy-pages@cd2ce8fcbc39b97be8ca5fce6e763baed58fa128  # v5.0.0


### PR DESCRIPTION
Closes #69

## 変更内容

`.github/workflows/build.yml` の各アクションを Node.js 24 対応版へ更新。SHA ピン留め + コメントのバージョン表記スタイルは維持。

| アクション | 旧 | 新 |
|---|---|---|
| `actions/checkout` | v4 (`34e11487...`) | **v6.0.2** (`de0fac2e...`) |
| `actions/setup-python` | v5 (`a26af69b...`) | **v6.2.0** (`a309ff8b...`) |
| `actions/upload-pages-artifact` | v3 (`56afc609...`) | **v5.0.0** (`fc324d35...`) |
| `actions/deploy-pages` | v4 (`d6db9016...`) | **v5.0.0** (`cd2ce8fc...`) |

## 変更理由

GitHub Actions ランナーで Node.js 20 が非推奨化されるため。

- 2026-06-02: Node.js 24 が強制デフォルト化
- 2026-09-16: Node.js 20 がランナーから削除
- 参考: <https://github.blog/changelog/2025-09-19-deprecation-of-node-20-on-github-actions-runners/>

## テスト方法

- [x] マージ後に `Summarize & Deploy` を `workflow_dispatch` で手動実行し、Node.js 20 非推奨アノテーションが出ないことを確認（[run 24925110670](https://github.com/unsolublesugar/tsuyu-mi/actions/runs/24925110670) — annotations なし）
- [x] 要約 → HTML 更新 → Pages デプロイが従来どおり成功することを確認（summarize 19s / deploy 8s でいずれも success）

🤖 Generated with [Claude Code](https://claude.com/claude-code)