### PR TITLE
add: ollamaProvider, OpencodeProvider

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,0 +1,23 @@
+// For format details, see https://aka.ms/devcontainer.json. For config options, see the
+// README at: https://github.com/devcontainers/templates/tree/main/src/python
+{
+	"name": "Python 3",
+	// Or use a Dockerfile or Docker Compose file. More info: https://containers.dev/guide/dockerfile
+	"image": "mcr.microsoft.com/devcontainers/python:3-3.13-trixie",
+
+	// Features to add to the dev container. More info: https://containers.dev/features.
+	// "features": {},
+
+	// Use 'forwardPorts' to make a list of ports inside the container available locally.
+	// "forwardPorts": [],
+	"runArgs": ["--add-host=host.docker.internal:host-gateway"],
+
+	// Use 'postCreateCommand' to run commands after the container is created.
+	"postCreateCommand": "pip3 install -e .",
+
+	// Configure tool-specific properties.
+	// "customizations": {},
+
+	// Uncomment to connect as root instead. More info: https://aka.ms/dev-containers-non-root.
+	// "remoteUser": "root"
+}

--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -1,0 +1,68 @@
+{
+    // Use IntelliSense to learn about possible attributes.
+    // Hover to view descriptions of existing attributes.
+    // For more information, visit: https://go.microsoft.com/fwlink/?linkid=830387
+    "version": "0.2.0",
+    "configurations": [
+        {
+            "name": "Raindrop 取得のみ",
+            "type": "debugpy",
+            "request": "launch",
+            "module": "src",
+            "args": ["fetch-only"]
+        },
+        {
+            "name": "少数で要約を試す",
+            "type": "debugpy",
+            "request": "launch",
+            "module": "src",
+            "args": ["run"],
+            "env": {
+                "MAX_SUMMARIZE_PER_RUN": "3"
+            }
+        },        {
+            "name": "フルパイプライン実行（取得 → 抽出 → 要約 → HTML 生成）",
+            "type": "debugpy",
+            "request": "launch",
+            "module": "src",
+            "args": ["run"]
+        },
+        {
+            "name": "対象記事を確認だけ（処理はしない）",
+            "type": "debugpy",
+            "request": "launch",
+            "module": "src",
+            "args": ["run", "--dry-run"]
+        },
+        {
+            "name": "詳細ログ付き実行",
+            "type": "debugpy",
+            "request": "launch",
+            "module": "src",
+            "args": ["run", "--verbose"]
+        },
+        {
+            "name": "HTML 再生成",
+            "type": "debugpy",
+            "request": "launch",
+            "module": "src",
+            "args": ["build-html"]
+        },
+        {
+            "name": "特定記事の再処理",
+            "type": "debugpy",
+            "request": "launch",
+            "module": "src",
+            "args": ["reprocess", "--id", "123456789"]  // ここに再処理したい記事のIDを指定
+        },
+        {
+            "name": "失敗記事の一括再試行",
+            "type": "debugpy",
+            "request": "launch",
+            "module": "src",
+            "args": ["reprocess-failed"]
+        },
+    ]
+}
+
+

--- a/README.md
+++ b/README.md
@@ -96,12 +96,19 @@ Obtain an API key from one of the following providers:
 1. Serve it by [`ollama run qwen3.5:9b`](https://docs.ollama.com/cli#run-a-model)
 2. You can use `dummy` as an API key if your server does not need any keys
 3. Recommanded model: `qwen3.5:9b` or better  
-    - Note: Summarization took ~70-300s/article on my Mac Mini M4 16GB. phi3 and llama3.2 sometimes struggled to output the correct JSON schema.
 4. You can specify the endpoint like `LLM_HOST=http://host.docker.internal:11434`.
 
-### 4. Configure environment variables
+> [!TIP]
+> Summarization took ~70-300s/article on my Mac Mini M4 16GB. phi3 and llama3.2 sometimes struggled to output the correct JSON schema.
 
-#### Local execution
+**Opencode**
+
+4. 接続先を指定できます (例: `LLM_HOST=http://localhost:4096`)
+
+1. Serve it by [`opencode serve`](https://opencode.ai/docs/ja/server)
+2. You can use `dummy` as an API key if your server does not need any keys
+3. Recommanded model: `opencode/big-pickle` or better  
+4. You can specify the endpoint like `LLM_HOST=http://localhost:4096`.
 
 ```bash
 cp .env.example .env

--- a/README.md
+++ b/README.md
@@ -91,6 +91,14 @@ Obtain an API key from one of the following providers:
 2. **Create Key**
 3. Recommended model: `claude-haiku-4-5-20251001`
 
+**LocalLLM(Ollama)**
+
+1. Serve it by [`ollama run qwen3.5:9b`](https://docs.ollama.com/cli#run-a-model)
+2. You can use `dummy` as an API key if your server does not need any keys
+3. Recommanded model: `qwen3.5:9b` or better  
+    - Note: Summarization took ~70-300s/article on my Mac Mini M4 16GB. phi3 and llama3.2 sometimes struggled to output the correct JSON schema.
+4. You can specify the endpoint like `LLM_HOST=http://host.docker.internal:11434`.
+
 ### 4. Configure environment variables
 
 #### Local execution

--- a/README_ja.md
+++ b/README_ja.md
@@ -96,8 +96,17 @@ pip install -e ".[dev]"
 1. [`ollama run qwen3.5:9b`](https://docs.ollama.com/cli#run-a-model) のように起動しておきます。
 2. APIキーが不要なら `dummy`とでも指定しておきましょう。
 3. 推奨モデル: `qwen3.5:9b`  
-    - 要約速度は手元のMac Mini M4 16GBで約70〜300秒/記事でした。phi3、llama3.2はjson応答が期待した形にならないことがありました。
 4. 接続先を指定できます (例: `LLM_HOST=http://host.docker.internal:11434`)
+
+> [!TIP]
+> 要約速度は手元のMac Mini M4 16GBで約70〜300秒/記事でした。phi3、llama3.2はjson応答が期待した形にならないことがありました。
+
+**Opencode**
+
+1. [`opencode serve`](https://opencode.ai/docs/ja/server/) のように起動しておきます。
+2. APIキーが不要なら `dummy`とでも指定しておきましょう。
+3. 推奨モデル: `opencode/big-pickle`
+4. 接続先を指定できます (例: `LLM_HOST=http://localhost:4096`)
 
 ### 4. 環境変数の設定
 

--- a/README_ja.md
+++ b/README_ja.md
@@ -91,6 +91,14 @@ pip install -e ".[dev]"
 2. **Create Key** でキーを生成
 3. 推奨モデル: `claude-haiku-4-5-20251001`
 
+**ローカルLLM(Ollama)**
+
+1. [`ollama run qwen3.5:9b`](https://docs.ollama.com/cli#run-a-model) のように起動しておきます。
+2. APIキーが不要なら `dummy`とでも指定しておきましょう。
+3. 推奨モデル: `qwen3.5:9b`  
+    - 要約速度は手元のMac Mini M4 16GBで約70〜300秒/記事でした。phi3、llama3.2はjson応答が期待した形にならないことがありました。
+4. 接続先を指定できます (例: `LLM_HOST=http://host.docker.internal:11434`)
+
 ### 4. 環境変数の設定
 
 #### ローカル実行の場合
@@ -176,9 +184,10 @@ python -m src reprocess-failed
 |---|---|---|
 | `RAINDROP_TOKEN` | Raindrop.io API テストトークン | （必須） |
 | `RAINDROP_COLLECTION_ID` | 対象コレクション ID | （必須） |
-| `LLM_PROVIDER` | `openai` / `gemini` / `anthropic` | `openai` |
+| `LLM_PROVIDER` | `openai` / `gemini` / `anthropic`/`ollama` | `openai` |
 | `LLM_API_KEY` | LLM の API キー | （必須） |
 | `LLM_MODEL` | 使用するモデル名 | （必須） |
+| `LLM_HOST` | LLM(Ollama)の接続先 | `http://localhost:11434` |
 | `MAX_SUMMARIZE_PER_RUN` | 1 回の要約件数上限 | `10` |
 | `REQUEST_TIMEOUT_SECONDS` | HTTP リクエストタイムアウト | `20` |
 | `USER_AGENT` | HTTP リクエストの User-Agent | `Tsuyu-mi/0.1` |

--- a/docs/specs/05_summarization.md
+++ b/docs/specs/05_summarization.md
@@ -20,6 +20,8 @@ class LLMProvider(Protocol):
 - `OpenAIProvider`: openai SDK
 - `GeminiProvider`: google-generativeai SDK
 - `AnthropicProvider`: anthropic SDK
+- `OllamaProvider`: ollama SDK
+- `OpenCodeProvider`: openai SDK（OpenAI 互換 API）
 
 ### Factory
 
@@ -29,6 +31,8 @@ def create_provider(config: Config) -> LLMProvider:
         case "openai": return OpenAIProvider(config)
         case "gemini": return GeminiProvider(config)
         case "anthropic": return AnthropicProvider(config)
+        case "ollama": return OllamaProvider(config)
+        case "opencode": return OpenCodeProvider(config)
 ```
 
 ## プロンプト

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -17,6 +17,7 @@ dependencies = [
     "openai>=1.60",
     "google-genai>=1.5",
     "anthropic>=0.44",
+    "ollama>=0.6.2",
 ]
 
 [project.optional-dependencies]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -18,6 +18,7 @@ dependencies = [
     "google-genai>=1.5",
     "anthropic>=0.44",
     "ollama>=0.6.2",
+    "opencode-ai>=0.1.0a36",
 ]
 
 [project.optional-dependencies]

--- a/src/config.py
+++ b/src/config.py
@@ -18,6 +18,7 @@ class Config(BaseSettings):
     data_dir: str = "data"
     state_dir: str = "state"
     log_level: str = "INFO"
+    llm_host: str = "http://localhost:11434"
 
     def validate_required(self) -> list[str]:
         """必須設定の未設定項目を返す。"""

--- a/src/summarizer.py
+++ b/src/summarizer.py
@@ -83,8 +83,20 @@ class OllamaProvider:
 
     def generate(self, prompt: str) -> str:
         response = self.client.chat(model=self.model, messages=[{"role": "user", "content": prompt}], stream=False)
-
         return response.message.content if response.message else ""
+
+class OpenCodeProvider(LLMProvider):
+    """OpenCode API プロバイダー（OpenAI 互換 API）。"""
+
+    def __init__(self, config: Config) -> None:
+        from opencode_ai import Opencode
+        self.client = Opencode(base_url=config.llm_host);
+        self.session = self.client.session.create(extra_body={"title": "raindrop_summarizer"});
+
+    def generate(self, prompt: str) -> str:
+        import httpx
+        response = self.client.post(f"/session/{self.session.id}/message", body={"parts": [{"type": "text", "text": prompt}]}, cast_to=httpx.Response);
+        return [x["text"] for x in response.json()["parts"] if x.get("type") == "text"][0] or ""
 
 def create_provider(config: Config) -> LLMProvider:
     """Config に基づき LLM プロバイダーを生成する。"""
@@ -97,6 +109,8 @@ def create_provider(config: Config) -> LLMProvider:
             return AnthropicProvider(config)
         case "ollama":
             return OllamaProvider(config)
+        case "opencode":
+            return OpenCodeProvider(config)
         case _:
             raise ValueError(f"未対応の LLM プロバイダー: {config.llm_provider}")
 

--- a/src/summarizer.py
+++ b/src/summarizer.py
@@ -73,6 +73,18 @@ class AnthropicProvider:
         )
         return response.content[0].text if response.content else ""
 
+class OllamaProvider:
+    """Ollama API プロバイダー。"""
+
+    def __init__(self, config: Config) -> None:
+        import ollama
+        self.client = ollama.Client(host=config.llm_host)
+        self.model = config.llm_model
+
+    def generate(self, prompt: str) -> str:
+        response = self.client.chat(model=self.model, messages=[{"role": "user", "content": prompt}], stream=False)
+
+        return response.message.content if response.message else ""
 
 def create_provider(config: Config) -> LLMProvider:
     """Config に基づき LLM プロバイダーを生成する。"""
@@ -83,6 +95,8 @@ def create_provider(config: Config) -> LLMProvider:
             return GeminiProvider(config)
         case "anthropic":
             return AnthropicProvider(config)
+        case "ollama":
+            return OllamaProvider(config)
         case _:
             raise ValueError(f"未対応の LLM プロバイダー: {config.llm_provider}")
 


### PR DESCRIPTION
## 変更内容

- LLMプロバイダにOllamaProviderを追加
- LLMプロバイダにOpencodeProviderを追加
- 依存ライブラリにOllamaライブラリを追加
- 依存ライブラリにOpencode-aiライブラリを追加
- ConfigにAPIエンドポイント(任意項目)を追加
- READMEにOllamaProviderに関する記載を追加
- READMEにOpencodeProviderに関する記載を追加
- DevContainerの起動設定を追加
- 対象ファイル:
  - `src/summarizer.py` (OllamaProvider,OpencodeProvider)
  - `src/config.py` (LLM_HOST)
  - `pyproject.toml` (ollamaライブラリ,opencode-aiライブラリ)
  - `README.md` (OllamaProvider、OpencodeProviderの設定方法)
  - `README_ja.md` (同上)
  - `.vscode/devcontainer.json` (VM起動用の設定)
  - `.vscode/launch.json` (tsuyu-mi起動用の設定)

## 変更理由

- ローカルLLM(Ollama)の利用を可能にする。
- Opencodeの利用を可能にする。

## 対象外

- `.env.example` に LLM_HOSTは追記していない (∵ 他プロバイダ利用時には指定不要なため)

## テスト方法

- [x] 要約 → HTML更新 が期待どおり成功することを確認

## LICENSE

- MIT